### PR TITLE
Lab 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main, feature/lab5]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Bonus safety: skip runs triggered by this workflow's own image-tag commits,
+    # so the auto-commit step below can't cause an infinite build loop.
+    if: "!startsWith(github.event.head_commit.message, 'ci:')"
+    permissions:
+      contents: write      # Needed to push the image-tag update commit back to main (bonus)
+      packages: write      # Needed to push images to ghcr.io
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ghcr.io requires a lowercase owner; normalize it once for every later step.
+      - name: Normalize owner to lowercase
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build + push all 3 services. Each image is tagged with the immutable commit
+      # SHA (for GitOps pinning) and with :latest (convenience / first-run bootstrap).
+      - name: Build and push images
+        run: |
+          SHA=${{ github.sha }}
+          for svc in gateway events payments; do
+            IMAGE="ghcr.io/${OWNER}/quickticket-${svc}"
+            echo "::group::build $IMAGE"
+            docker build -t "${IMAGE}:${SHA}" -t "${IMAGE}:latest" "./app/${svc}"
+            docker push "${IMAGE}:${SHA}"
+            docker push "${IMAGE}:latest"
+            echo "::endgroup::"
+          done
+
+      # --- Bonus Task: close the GitOps loop automatically ---
+      # Rewrite the image tag in each manifest to the SHA we just built, then commit
+      # the change back to main. ArgoCD picks it up and deploys without manual steps.
+      - name: Update image tags in manifests
+        run: |
+          SHA=${{ github.sha }}
+          for svc in gateway events payments; do
+            sed -i "s|image: ghcr.io/.*/quickticket-${svc}:.*|image: ghcr.io/${OWNER}/quickticket-${svc}:${SHA}|" "k8s/${svc}.yaml"
+          done
+
+      - name: Commit and push manifest update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add k8s/
+          git diff --cached --quiet || git commit -m "ci: update image tags to ${{ github.sha }}"
+          # Push the branch that triggered this run (robust even if HEAD is detached).
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: quickticket
+description: QuickTicket SRE learning project
+type: application
+version: 0.1.0
+appVersion: "v1"

--- a/k8s/chart/templates/events.yaml
+++ b/k8s/chart/templates/events.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+  labels:
+    app: events
+spec:
+  replicas: {{ .Values.events.replicas }}
+  selector:
+    matchLabels:
+      app: events
+  template:
+    metadata:
+      labels:
+        app: events
+    spec:
+      containers:
+        - name: events
+          image: {{ .Values.events.image }}
+          imagePullPolicy: Never
+          env:
+            - name: DB_HOST
+              value: {{ .Values.events.db.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.events.db.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.events.db.name | quote }}
+            - name: DB_USER
+              value: {{ .Values.events.db.user | quote }}
+            - name: DB_PASS
+              value: {{ .Values.events.db.password | quote }}
+            - name: REDIS_HOST
+              value: {{ .Values.events.redis.host | quote }}
+            - name: REDIS_PORT
+              value: {{ .Values.events.redis.port | quote }}
+          ports:
+            - containerPort: 8081
+          livenessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: events
+spec:
+  selector:
+    app: events
+  ports:
+    - port: 8081
+      targetPort: 8081

--- a/k8s/chart/templates/gateway.yaml
+++ b/k8s/chart/templates/gateway.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+spec:
+  replicas: {{ .Values.gateway.replicas }}
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: {{ .Values.gateway.image }}
+          imagePullPolicy: Never
+          env:
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: GATEWAY_TIMEOUT_MS
+              value: {{ .Values.gateway.timeoutMs | quote }}
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/chart/templates/payments.yaml
+++ b/k8s/chart/templates/payments.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  labels:
+    app: payments
+spec:
+  replicas: {{ .Values.payments.replicas }}
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      containers:
+        - name: payments
+          image: {{ .Values.payments.image }}
+          imagePullPolicy: Never
+          env:
+            - name: PAYMENT_FAILURE_RATE
+              value: {{ .Values.payments.failureRate | quote }}
+            - name: PAYMENT_LATENCY_MS
+              value: {{ .Values.payments.latencyMs | quote }}
+          ports:
+            - containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            periodSeconds: 5
+            failureThreshold: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+spec:
+  selector:
+    app: payments
+  ports:
+    - port: 8082
+      targetPort: 8082

--- a/k8s/chart/templates/postgres.yaml
+++ b/k8s/chart/templates/postgres.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.db | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.postgres.password | quote }}
+          ports:
+            - containerPort: 5432
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/chart/templates/redis.yaml
+++ b/k8s/chart/templates/redis.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -1,0 +1,41 @@
+# Shared resource requests/limits applied to every container.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+gateway:
+  replicas: 1
+  image: quickticket-gateway:v1
+  timeoutMs: "5000"
+
+events:
+  replicas: 1
+  image: quickticket-events:v1
+  db:
+    host: postgres
+    port: 5432
+    name: quickticket
+    user: quickticket
+    password: quickticket
+  redis:
+    host: redis
+    port: 6379
+
+payments:
+  replicas: 1
+  image: quickticket-payments:v1
+  failureRate: "0.0"
+  latencyMs: "0"
+
+postgres:
+  image: postgres:17-alpine
+  db: quickticket
+  user: quickticket
+  password: quickticket
+
+redis:
+  image: redis:7-alpine

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: events
-          image: ghcr.io/jakefish18/quickticket-events:52037579b761e85cd77ea99ac3b005a371cdc532
+          image: ghcr.io/jakefish18/quickticket-events:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
           imagePullPolicy: Always
           env:
             - name: DB_HOST

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+  labels:
+    app: events
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: events
+  template:
+    metadata:
+      labels:
+        app: events
+    spec:
+      containers:
+        - name: events
+          image: quickticket-events:v1
+          imagePullPolicy: Never
+          env:
+            - name: DB_HOST
+              value: "postgres"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "quickticket"
+            - name: DB_USER
+              value: "quickticket"
+            - name: DB_PASS
+              value: "quickticket"
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          ports:
+            - containerPort: 8081
+          # Liveness = TCP (process alive). events' /health checks Postgres + Redis, so an
+          # httpGet /health liveness would RESTART events whenever a datastore blips — the
+          # DB-connectivity anti-pattern. Readiness = /health so events is removed from the
+          # Service endpoints (0/1 Ready) while a dependency is down, then re-added on recovery.
+          livenessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: events
+spec:
+  selector:
+    app: events
+  ports:
+    - port: 8081
+      targetPort: 8081

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
         - name: events
-          image: quickticket-events:v1
-          imagePullPolicy: Never
+          image: ghcr.io/jakefish18/quickticket-events:latest
+          imagePullPolicy: Always
           env:
             - name: DB_HOST
               value: "postgres"

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: events
-          image: ghcr.io/jakefish18/quickticket-events:latest
+          image: ghcr.io/jakefish18/quickticket-events:52037579b761e85cd77ea99ac3b005a371cdc532
           imagePullPolicy: Always
           env:
             - name: DB_HOST

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: events
-          image: ghcr.io/jakefish18/quickticket-events:1c2c8f66e4f8ea2958717f8115a7af3e2d846511
+          image: ghcr.io/jakefish18/quickticket-events:44a1520645acc7a36347ccd333e64543801011ad
           imagePullPolicy: Always
           env:
             - name: DB_HOST

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: events
-          image: ghcr.io/jakefish18/quickticket-events:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
+          image: ghcr.io/jakefish18/quickticket-events:1c2c8f66e4f8ea2958717f8115a7af3e2d846511
           imagePullPolicy: Always
           env:
             - name: DB_HOST

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gateway
   labels:
     app: gateway
+    version: "v2"
 spec:
   replicas: 1
   selector:

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: ghcr.io/jakefish18/quickticket-gateway:does-not-exist
+          image: ghcr.io/jakefish18/quickticket-gateway:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
           imagePullPolicy: Always
           env:
             - name: EVENTS_URL

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: ghcr.io/jakefish18/quickticket-gateway:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
+          image: ghcr.io/jakefish18/quickticket-gateway:does-not-exist
           imagePullPolicy: Always
           env:
             - name: EVENTS_URL

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: quickticket-gateway:v1
+          imagePullPolicy: Never
+          env:
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: GATEWAY_TIMEOUT_MS
+              value: "5000"
+          ports:
+            - containerPort: 8080
+          # Liveness = "is the process alive?" — TCP check, NOT /health, because the
+          # gateway's /health is dependency-aware (503 when events/payments are down).
+          # An httpGet /health liveness would restart the gateway on a downstream outage,
+          # which never helps. Readiness uses /health so a degraded gateway is pulled
+          # from Service endpoints (stops traffic) without being killed.
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: ghcr.io/jakefish18/quickticket-gateway:52037579b761e85cd77ea99ac3b005a371cdc532
+          image: ghcr.io/jakefish18/quickticket-gateway:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
           imagePullPolicy: Always
           env:
             - name: EVENTS_URL

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: quickticket-gateway:v1
-          imagePullPolicy: Never
+          image: ghcr.io/jakefish18/quickticket-gateway:latest
+          imagePullPolicy: Always
           env:
             - name: EVENTS_URL
               value: "http://events:8081"

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: ghcr.io/jakefish18/quickticket-gateway:1c2c8f66e4f8ea2958717f8115a7af3e2d846511
+          image: ghcr.io/jakefish18/quickticket-gateway:44a1520645acc7a36347ccd333e64543801011ad
           imagePullPolicy: Always
           env:
             - name: EVENTS_URL

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: ghcr.io/jakefish18/quickticket-gateway:latest
+          image: ghcr.io/jakefish18/quickticket-gateway:52037579b761e85cd77ea99ac3b005a371cdc532
           imagePullPolicy: Always
           env:
             - name: EVENTS_URL

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: gateway
-          image: ghcr.io/jakefish18/quickticket-gateway:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
+          image: ghcr.io/jakefish18/quickticket-gateway:1c2c8f66e4f8ea2958717f8115a7af3e2d846511
           imagePullPolicy: Always
           env:
             - name: EVENTS_URL

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
         - name: payments
-          image: quickticket-payments:v1
-          imagePullPolicy: Never
+          image: ghcr.io/jakefish18/quickticket-payments:latest
+          imagePullPolicy: Always
           env:
             - name: PAYMENT_FAILURE_RATE
               value: "0.0"

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: payments
-          image: ghcr.io/jakefish18/quickticket-payments:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
+          image: ghcr.io/jakefish18/quickticket-payments:1c2c8f66e4f8ea2958717f8115a7af3e2d846511
           imagePullPolicy: Always
           env:
             - name: PAYMENT_FAILURE_RATE

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: payments
-          image: ghcr.io/jakefish18/quickticket-payments:latest
+          image: ghcr.io/jakefish18/quickticket-payments:52037579b761e85cd77ea99ac3b005a371cdc532
           imagePullPolicy: Always
           env:
             - name: PAYMENT_FAILURE_RATE

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: payments
-          image: ghcr.io/jakefish18/quickticket-payments:52037579b761e85cd77ea99ac3b005a371cdc532
+          image: ghcr.io/jakefish18/quickticket-payments:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
           imagePullPolicy: Always
           env:
             - name: PAYMENT_FAILURE_RATE

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  labels:
+    app: payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      containers:
+        - name: payments
+          image: quickticket-payments:v1
+          imagePullPolicy: Never
+          env:
+            - name: PAYMENT_FAILURE_RATE
+              value: "0.0"
+            - name: PAYMENT_LATENCY_MS
+              value: "0"
+          ports:
+            - containerPort: 8082
+          # payments' /health is self-contained (no downstream dependencies), so it is
+          # safe to use httpGet /health for BOTH liveness and readiness here — a failing
+          # /health genuinely means this process is broken and a restart may help.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+spec:
+  selector:
+    app: payments
+  ports:
+    - port: 8082
+      targetPort: 8082

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: payments
-          image: ghcr.io/jakefish18/quickticket-payments:1c2c8f66e4f8ea2958717f8115a7af3e2d846511
+          image: ghcr.io/jakefish18/quickticket-payments:44a1520645acc7a36347ccd333e64543801011ad
           imagePullPolicy: Always
           env:
             - name: PAYMENT_FAILURE_RATE

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: "quickticket"
+            - name: POSTGRES_USER
+              value: "quickticket"
+            - name: POSTGRES_PASSWORD
+              value: "quickticket"
+          ports:
+            - containerPort: 5432
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/submissions/lab4.md
+++ b/submissions/lab4.md
@@ -1,0 +1,253 @@
+# Lab 4 — Kubernetes: Deploy QuickTicket to a Cluster
+
+**Author:** jakefish18
+**Cluster:** k3d `5.9.0` running k3s `v1.35.5+k3s1` (1 node), `kubectl`, `helm 4.2.0`.
+
+> Manifests live in [`k8s/`](../k8s) (postgres, redis, events, payments, gateway) and the
+> Helm chart in [`k8s/chart/`](../k8s/chart). Two local adaptations: the gateway
+> port-forward uses **local port 3090** (host `3080` is still taken by the Lab 1–3
+> docker-compose gateway), and Postgres is **ephemeral** (no PVC, per the lab) so its seed
+> is re-loaded whenever the postgres pod is recreated.
+---
+
+## Task 1 — Write Manifests & Deploy to k3d
+
+### 1) `kubectl get nodes`
+
+```
+NAME                       STATUS   ROLES           AGE     VERSION
+k3d-quickticket-server-0   Ready    control-plane   2m16s   v1.35.5+k3s1
+```
+
+Images were built locally and imported into the cluster
+(`k3d image import quickticket-{gateway,events,payments}:v1`), so every app Deployment
+uses `imagePullPolicy: Never`. Postgres/Redis use the public `postgres:17-alpine` /
+`redis:7-alpine` images (`imagePullPolicy: IfNotPresent`).
+
+### 2) `kubectl get pods,svc` — all running
+
+```
+NAME                           READY   STATUS    RESTARTS   AGE     IP
+pod/events-859d5c5c98-cmzw4    1/1     Running   0          24s     10.42.0.14
+pod/gateway-6fc44f68c5-4j5gb   1/1     Running   0          3m16s   10.42.0.13
+pod/payments-58fb468db-26hgw   1/1     Running   0          3m16s   10.42.0.12
+pod/postgres-7c7ffc4b-98l4c    1/1     Running   0          3m28s   10.42.0.10
+pod/redis-c46d5dffc-pmchx      1/1     Running   0          3m28s   10.42.0.9
+NAME                 TYPE        CLUSTER-IP      PORT(S)    SELECTOR
+service/events       ClusterIP   10.43.37.61     8081/TCP   app=events
+service/gateway      ClusterIP   10.43.146.15    8080/TCP   app=gateway
+service/payments     ClusterIP   10.43.3.222     8082/TCP   app=payments
+service/postgres     ClusterIP   10.43.166.235   5432/TCP   app=postgres
+service/redis        ClusterIP   10.43.12.9      6379/TCP   app=redis
+service/kubernetes   ClusterIP   10.43.0.1       443/TCP
+```
+
+> Startup ordering: K8s has no `depends_on`. I avoided the race by applying
+> `postgres.yaml`+`redis.yaml` first and `kubectl wait`-ing for them before applying the
+> app services, so `events` connected on its first try (it also has a 10× retry loop).
+> The fallback `kubectl rollout restart deployment/events` is the documented fix if events
+> starts before Postgres is ready.
+### 3) Full stack via port-forward (`kubectl port-forward svc/gateway 3090:8080`)
+
+```json
+$ curl -s http://localhost:3090/events
+[
+  {"id": 1, "name": "Go Conference 2026", "venue": "Main Hall A", "total_tickets": 100, "price_cents": 5000, "available": 100},
+  {"id": 4, "name": "Python Workshop", "venue": "Lab 301", "total_tickets": 25, "price_cents": 2000, "available": 25},
+  ... 5 events total ...
+]
+
+$ curl -s http://localhost:3090/health
+{"status":"healthy","checks":{"events":"ok","payments":"ok","circuit_payments":"CLOSED"}}
+```
+
+(The DB was seeded with `kubectl exec -i $(kubectl get pod -l app=postgres -o name) --
+psql -U quickticket -d quickticket -f /dev/stdin < app/seed.sql` → `CREATE TABLE ×2,
+INSERT 0 5`.)
+
+### 4) Self-healing — `kubectl get pods -w` during pod deletion
+
+```
+old gateway pod: gateway-6fc44f68c5-4j5gb
+$ kubectl delete pod gateway-6fc44f68c5-4j5gb        # t=0
+t=+0s  gateway-6fc44f68c5-4j5gb 1/1 Terminating | gateway-6fc44f68c5-7xsrg 0/1 ContainerCreating
+t=+1s  gateway-6fc44f68c5-7xsrg 1/1 Running
+>>> new pod gateway-6fc44f68c5-7xsrg Ready (1/1 Running) at t=+1s <<<
+$ kubectl get deploy gateway
+NAME      READY   UP-TO-DATE   AVAILABLE   AGE
+gateway   1/1     1            1           3m18s
+```
+
+### 5) Recovery time vs docker-compose
+
+**K8s recreated the pod and had it `Ready` in ~1 second, with zero human action.** The
+Deployment's ReplicaSet controller runs a continuous reconcile loop: desired `replicas: 1`
+≠ actual `0` → it immediately schedules a replacement (fast here because the image was
+already on the node). In **Lab 1**, a killed docker-compose service stayed **down until I
+manually ran `docker compose start <service>`** — Compose has no controller watching
+desired state. That self-healing reconcile loop is the core operational difference: K8s
+treats "1 replica running" as a goal it keeps re-asserting, not a one-time action.
+
+---
+
+## Task 2 — Probes & Resource Limits
+
+### Probe design (a deliberate, important choice)
+
+`gateway`'s and `events`' `/health` are **dependency-aware** (they return `503` when a
+downstream service / Postgres / Redis is down). A **liveness** probe on such an endpoint
+would make the kubelet **restart** the pod every time a *dependency* blips — which never
+fixes the dependency and can turn a brief outage into a CrashLoop. So:
+
+- **gateway, events:** `livenessProbe: tcpSocket` (just "is the process alive?") +
+  `readinessProbe: httpGet /health` (dependency-aware → pulls the pod from Service
+  endpoints when degraded, without killing it).
+- **payments:** `/health` is self-contained (no downstream deps), so `httpGet /health` is
+  safe for **both** liveness and readiness here.
+
+### `kubectl describe pod` — probes configured
+
+```
+gateway   Liveness:   tcp-socket :8080 delay=10s period=10s #failure=3
+          Readiness:  http-get http://:8080/health period=5s #failure=2
+events    Liveness:   tcp-socket :8081 delay=10s period=10s #failure=3
+          Readiness:  http-get http://:8081/health period=5s #failure=2
+payments  Liveness:   http-get http://:8082/health delay=10s period=10s #failure=3
+          Readiness:  http-get http://:8082/health period=5s #failure=2
+```
+
+### Readiness failure during a Redis outage
+
+I scaled Redis to 0 (a plain `kubectl delete pod` self-heals in ~1 s — too short to cross
+the 2×5 s readiness threshold), so `events`' `/health` starts returning `503`:
+
+```
+baseline   events 1/1 Ready   endpoints=[10.42.0.16]
+$ kubectl scale deploy/redis --replicas=0
+t=+ 9s  READY=1/1 STATUS=Running RESTARTS=0  endpoints=[10.42.0.16]
+t=+12s  READY=0/1 STATUS=Running RESTARTS=0  endpoints=[]      <-- removed from Service
+t=+27s  READY=0/1 STATUS=Running RESTARTS=0  endpoints=[]
+describe: Warning Unhealthy ... Readiness probe failed: HTTP probe failed with statuscode: 503
+$ kubectl scale deploy/redis --replicas=1
+t=+ 6s  READY=1/1 STATUS=Running RESTARTS=0   <-- readiness recovers, RESTARTS still 0
+```
+
+`events` went **`0/1 Ready`** and was **removed from the Service endpoints** (no traffic
+routed to it), but **`RESTARTS` stayed `0`** — the tcpSocket liveness kept it alive. When
+Redis returned, readiness passed and the pod was re-added. (The same cascade is visible
+upstream: with events out of its endpoints, the gateway's readiness `/health` also reports
+events down — graceful degradation, no restarts anywhere.)
+
+### Resource limits — node allocation
+
+Each container has `requests: 50m/64Mi`, `limits: 200m/256Mi`.
+
+```
+Allocated resources:
+  Resource   Requests    Limits
+  cpu        450m (3%)   1 (8%)
+  memory     460Mi (5%)  1450Mi (18%)
+```
+
+```
+$ kubectl top pods
+events     5m   44Mi
+gateway    5m   38Mi
+payments   4m   36Mi
+postgres   1m   38Mi
+redis      7m    3Mi
+```
+
+(450m/460Mi requests = our 5 pods' requests + k3s system pods; actual usage is far below
+the limits.)
+
+### Liveness vs readiness — which for DB connectivity, and why?
+
+- **Liveness failure → kubelet kills & restarts the container.** Use it only for "the
+  process is wedged/deadlocked and a restart will fix it."
+- **Readiness failure → pod removed from Service endpoints (no traffic), NOT restarted;**
+  re-added when it passes again. Use it for "temporarily can't serve" — warming up, or a
+  dependency is unavailable.
+
+**For database connectivity, use readiness, not liveness.** If the DB is down, restarting
+the app pod does nothing to fix the DB — it would just CrashLoop (and a fleet of
+simultaneous restarts/reconnects can make the outage worse). Readiness correctly stops
+routing traffic to a pod that can't serve and resumes the instant the DB recovers, with no
+pointless restarts. My run proves it: `events` (readiness = DB/Redis-aware `/health`) went
+`0/1 Ready` with `RESTARTS=0` during the Redis outage; had `/health` been a *liveness*
+probe, events would have been killed every ~30 s while Redis was down.
+
+---
+
+## Bonus Task — Helm Chart
+
+Converted the raw manifests into a chart at `k8s/chart/` (`Chart.yaml`, `values.yaml`,
+`templates/{postgres,redis,events,payments,gateway}.yaml`). Hardcoded values (`replicas`,
+`image`, env vars, and the shared `resources` block via `{{ toYaml .Values.resources }}`)
+are now driven from `values.yaml`.
+
+**`Chart.yaml`**
+```yaml
+apiVersion: v2
+name: quickticket
+description: QuickTicket SRE learning project
+type: application
+version: 0.1.0
+appVersion: "v1"
+```
+**`values.yaml`** (excerpt)
+```yaml
+resources:
+  requests: { cpu: 50m, memory: 64Mi }
+  limits:   { cpu: 200m, memory: 256Mi }
+gateway:  { replicas: 1, image: quickticket-gateway:v1, timeoutMs: "5000" }
+events:
+  replicas: 1
+  image: quickticket-events:v1
+  db:    { host: postgres, port: 5432, name: quickticket, user: quickticket, password: quickticket }
+  redis: { host: redis, port: 6379 }
+payments: { replicas: 1, image: quickticket-payments:v1, failureRate: "0.0", latencyMs: "0" }
+postgres: { image: postgres:17-alpine, db: quickticket, user: quickticket, password: quickticket }
+redis:    { image: redis:7-alpine }
+```
+
+`helm lint` → `0 chart(s) failed`. After `kubectl delete -f k8s/{postgres,redis,events,
+payments,gateway}.yaml` and `helm install quickticket k8s/chart/`:
+
+```
+$ helm list
+NAME         NAMESPACE  REVISION  STATUS    CHART              APP VERSION
+quickticket  default    1         deployed  quickticket-0.1.0  v1
+$ kubectl get pods
+NAME                        READY   STATUS    RESTARTS   AGE
+events-5c97fcbb69-wwpfk     1/1     Running   0          59s
+gateway-97f8b986b-knclg     1/1     Running   0          59s
+payments-d7dc94485-75fsr    1/1     Running   0          59s
+postgres-78489d7f5f-tn8s8   1/1     Running   0          59s
+redis-6fcfb5475d-g479q      1/1     Running   0          59s
+```
+
+End-to-end on the Helm-managed stack (after re-seeding the fresh Postgres pod):
+```
+/events  -> 5 events (first = "Go Conference 2026")
+/health  -> {"status":"healthy", ...}
+/pay     -> {"order_id":"a446aa4e-...","status":"confirmed"}
+```
+
+> The optional `kube-prometheus-stack` monitoring sub-step was not installed (it pulls a
+> large multi-pod stack); the chart + release requirements above are all satisfied.
+
+---
+
+## Summary
+
+- Wrote all five Deployment+Service manifests from scratch, built+imported local images,
+  deployed to k3d, seeded Postgres, and verified the full critical path through a
+  port-forward.
+- **Self-healing:** a deleted pod was back `Ready` in ~1 s with no human action — vs
+  docker-compose, which needed a manual `start`.
+- Added **tcpSocket liveness + httpGet /health readiness** (so a dependency outage pulls a
+  pod from Service endpoints instead of restarting it) and resource requests/limits;
+  demonstrated `events` going `0/1 Ready` with `RESTARTS=0` during a Redis outage.
+- Packaged everything as a working Helm chart (`helm install` → all pods Running,
+  end-to-end purchase succeeds).

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -23,27 +23,76 @@ PR checklist:
 
 ### 1. GitHub Actions run (green check)
 
-<!-- ACTIONS_RUN -->
+- ✅ https://github.com/jakefish18/SRE-Intro/actions/runs/28267406118 — *feat(lab5): add CI/CD pipeline and ArgoCD GitOps* (initial pipeline, builds + pushes all 3 images)
+- ✅ https://github.com/jakefish18/SRE-Intro/actions/runs/28334004365 — *feat: add version label to gateway* (re-build + auto-tag)
+
+All workflow steps (build + push images, update image tags, commit/push) completed
+green in ~55s.
 
 ### 2. Images pushed to ghcr.io
 
+The lab's `gh api user/packages?package_type=container` requires a token with the
+`read:packages` scope; the `gh` CLI's OAuth token does not have it, so that exact
+call returns 403:
+
 ```
-<!-- PACKAGES -->
+$ gh api "user/packages?package_type=container" --jq '.[].name'
+{"message":"You need at least read:packages scope to list packages.", ... "status":"403"}
 ```
+
+Equivalent proof — the three images are published and **public** on ghcr.io
+(anonymous registry manifest request returns HTTP 200 for the built SHA):
+
+```
+$ for svc in gateway events payments; do ... ghcr.io/v2/jakefish18/quickticket-$svc/manifests/<sha> ; done
+ghcr.io/jakefish18/quickticket-gateway   ->  HTTP 200
+ghcr.io/jakefish18/quickticket-events    ->  HTTP 200
+ghcr.io/jakefish18/quickticket-payments  ->  HTTP 200
+```
+
+They are also visible at https://github.com/jakefish18?tab=packages.
+
 
 ### 3. `argocd app get quickticket` — Synced + Healthy
 
 ```
-<!-- ARGOCD_GET -->
+Name:               argocd/quickticket
+Project:            default
+Server:             https://kubernetes.default.svc
+Namespace:          default
+Source:
+- Repo:             https://github.com/jakefish18/SRE-Intro.git
+  Target:           feature/lab5
+  Path:             k8s
+Sync Policy:        Automated
+Sync Status:        Synced to feature/lab5 (15feeb5)
+Health Status:      Healthy
+
+GROUP  KIND        NAMESPACE  NAME      STATUS  HEALTH   MESSAGE
+       Service     default    gateway   Synced  Healthy  service/gateway unchanged
+       Service     default    events    Synced  Healthy  service/events unchanged
+       Service     default    payments  Synced  Healthy  service/payments unchanged
+       Service     default    postgres  Synced  Healthy  service/postgres unchanged
+       Service     default    redis     Synced  Healthy  service/redis unchanged
+apps   Deployment  default    gateway   Synced  Healthy  deployment.apps/gateway unchanged
+apps   Deployment  default    events    Synced  Healthy  deployment.apps/events unchanged
+apps   Deployment  default    payments  Synced  Healthy  deployment.apps/payments unchanged
+apps   Deployment  default    postgres  Synced  Healthy  deployment.apps/postgres unchanged
+apps   Deployment  default    redis     Synced  Healthy  deployment.apps/redis unchanged
 ```
 
 ### 4. Proof a Git change was synced to the cluster
 
-A `version: "v2"` label was added to the gateway Deployment in Git, pushed, and
-synced by ArgoCD:
+A `version: "v2"` label was added to the gateway Deployment in Git (commit
+`b4dbad3`), pushed, and synced by ArgoCD. The label is live in the cluster, and the
+running image is the SHA the CI auto-tagged:
 
 ```
-<!-- GITOPS_PROOF -->
+$ kubectl get deployment gateway -n default -o jsonpath='{.metadata.labels.version}'
+v2
+
+$ kubectl get deployment gateway -n default -o jsonpath='{.spec.template.spec.containers[0].image}'
+ghcr.io/jakefish18/quickticket-gateway:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
 ```
 
 ### 5. What happens if someone runs `kubectl edit` on an ArgoCD-managed resource?
@@ -75,33 +124,67 @@ Git and let ArgoCD apply it.
 
 ## Task 2 — Rollback via GitOps
 
-### Bad deploy — `argocd app get` showing Degraded
+The broken version (`image: ghcr.io/jakefish18/quickticket-gateway:does-not-exist`)
+was committed as `b06d5e6`. The commit message starts with `ci:` *on purpose* so the
+workflow's auto-tag step is skipped — otherwise the bonus pipeline would rebuild and
+overwrite the bad tag with a valid SHA, "healing" the break before ArgoCD could show
+it.
+
+### Bad deploy — `argocd app get` showing Degraded/Progressing
 
 ```
-<!-- BAD_ARGOCD -->
+Sync Status:        Synced to feature/lab5 (b06d5e6)
+Health Status:      Progressing
+
+GROUP  KIND        NAMESPACE  NAME     STATUS  HEALTH       MESSAGE
+apps   Deployment  default    gateway  Synced  Progressing  deployment.apps/gateway configured
 ```
+
+(ArgoCD holds at `Progressing`; it flips to `Degraded` once the Deployment's
+`progressDeadlineSeconds` — default 600s — is exceeded. The new ReplicaSet can never
+become ready because the image does not exist.)
 
 ### `kubectl get pods` showing ImagePullBackOff
 
 ```
-<!-- BAD_PODS -->
+$ kubectl get pods -n default | grep gateway
+gateway-667b76d744-rpbkh    1/1     Running            0          23m   <- old good pod still serving
+gateway-868895d66c-tltlw    0/1     ImagePullBackOff   0          43s   <- new bad pod
 ```
+
+The rolling update keeps the old pod up (so the Service stays available) while the
+new pod is stuck pulling the non-existent image.
 
 ### `git log --oneline -3` showing deploy + revert
 
 ```
-<!-- ROLLBACK_LOG -->
+$ git log --oneline -3
+1c2c8f6 Revert "ci: task2 deploy broken gateway tag (intentional bad deploy)"
+b06d5e6 ci: task2 deploy broken gateway tag (intentional bad deploy)
+15feeb5 ci: update image tags to b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
 ```
 
 ### After `git revert` — `argocd app get` showing Healthy
 
 ```
-<!-- GOOD_ARGOCD -->
+Sync Status:   Synced to feature/lab5 (1c2c8f6)
+Health Status: Healthy
+
+$ kubectl get pods -n default | grep gateway
+gateway-667b76d744-rpbkh    1/1     Running   0   26m
 ```
 
 ### How long from `git revert` + push to pods healthy again?
 
-<!-- ROLLBACK_TIME -->
+**~6 seconds** when recovery is triggered with `argocd app sync` (measured: revert
+push → `argocd app wait --health` returning Healthy = 6s). Recovery was near-instant
+because the revert restored the previous good image (`…:b4dbad3…`), which was already
+cached on the node and whose old pod had never been torn down — ArgoCD simply scaled
+the broken ReplicaSet to 0.
+
+Without a manual sync, ArgoCD's default Git poll interval is **~3 minutes**, so an
+unattended rollback would heal within that window. (A fresh image that still needed
+pulling would add the pull time on top.)
 
 ---
 
@@ -116,12 +199,40 @@ syncs the auto-updated tag with no human intervention.
 
 ### Git log showing: code commit → CI tag-update commit
 
+Each human/code commit is immediately followed by an automated `ci: update image
+tags to <sha>` commit authored by the workflow:
+
 ```
-<!-- BONUS_LOG -->
+$ git log --oneline -5
+15feeb5 ci: update image tags to b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c   <- CI auto-commit
+b4dbad3 feat: add version label to gateway                                  <- my commit
+7a9e968 ci: update image tags to 52037579b761e85cd77ea99ac3b005a371cdc532   <- CI auto-commit
+5203757 feat(lab5): add CI/CD pipeline and ArgoCD GitOps                    <- my commit
+3634ca7 feat: solution
 ```
 
 ### ArgoCD syncing the auto-updated tag
 
+ArgoCD synced to the CI-authored commit `15feeb5` with no manual edit to the
+manifests — the image tag in `k8s/gateway.yaml` was written by CI, and ArgoCD
+deployed it:
+
 ```
-<!-- BONUS_SYNC -->
+Sync Status:   Synced to feature/lab5 (15feeb5)
+Health Status: Healthy
+running image: ghcr.io/jakefish18/quickticket-gateway:b4dbad3edacdf1c055234d40b3d7b263eb3d0e9c
+```
+
+**Loop guard:** the `ci:` commit does **not** re-trigger the workflow because of
+`if: "!startsWith(github.event.head_commit.message, 'ci:')"` (and GitHub also does
+not run workflows for pushes made with the default `GITHUB_TOKEN`). No infinite loop.
+
+Concrete evidence — the Task 2 bad-deploy commit `b06d5e6` (message prefixed `ci:`)
+shows a **skipped** workflow run, while normal commits run green:
+
+```
+$ gh run list --branch feature/lab5
+completed  success  1c2c8f6  Revert "ci: task2 deploy broken gateway tag ..."
+completed  skipped  b06d5e6  ci: task2 deploy broken gateway tag (intentional bad deploy)
+completed  success  b4dbad3  feat: add version label to gateway
 ```

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -1,0 +1,127 @@
+# Lab 5 — CI/CD & GitOps — Submission
+
+**Student:** jakefish18
+**Repo:** https://github.com/jakefish18/SRE-Intro
+**Branch:** `feature/lab5`
+
+PR checklist:
+```text
+- [x] Task 1 done — CI pipeline + ArgoCD deployed + GitOps loop verified
+- [x] Task 2 done — rollback via git revert
+- [x] Bonus Task done — automated image tag update
+```
+
+> **Note on environment:** to keep `main` clean, the CI workflow triggers on
+> `feature/lab5` (in addition to `main`) and the ArgoCD Application tracks the
+> `feature/lab5` revision. The GitOps mechanics are identical to tracking `main`.
+> ghcr.io packages were made **public**, so no `imagePullSecret` is required
+> (`imagePullPolicy: Always` pulls anonymously).
+
+---
+
+## Task 1 — CI Pipeline + ArgoCD Setup
+
+### 1. GitHub Actions run (green check)
+
+<!-- ACTIONS_RUN -->
+
+### 2. Images pushed to ghcr.io
+
+```
+<!-- PACKAGES -->
+```
+
+### 3. `argocd app get quickticket` — Synced + Healthy
+
+```
+<!-- ARGOCD_GET -->
+```
+
+### 4. Proof a Git change was synced to the cluster
+
+A `version: "v2"` label was added to the gateway Deployment in Git, pushed, and
+synced by ArgoCD:
+
+```
+<!-- GITOPS_PROOF -->
+```
+
+### 5. What happens if someone runs `kubectl edit` on an ArgoCD-managed resource?
+
+ArgoCD continuously compares the **live** cluster state against the **desired**
+state in Git (the source of truth). A manual `kubectl edit` makes the live state
+diverge, so ArgoCD immediately reports the Application as **OutOfSync** and shows
+the manual change as a diff (`argocd app diff`).
+
+What happens next depends on the sync policy:
+
+- **`automated` + `selfHeal`** → ArgoCD automatically reverts the manual edit back
+  to the Git-defined state within the reconciliation interval. The manual change is
+  effectively impossible to keep — Git wins.
+- **`automated` without selfHeal** (what the lab's `--sync-policy automated`
+  configures) → the app is flagged OutOfSync but the drift is *not* auto-reverted
+  until the next sync is triggered (a new Git commit, a manual `argocd app sync`,
+  or enabling self-heal). Running `argocd app sync` (or `--self-heal`) restores Git
+  state.
+- **Manual sync policy** → the edit persists and the app simply stays OutOfSync
+  until someone syncs.
+
+**Bottom line:** out-of-band `kubectl edit` is an anti-pattern under GitOps — it's
+either reverted automatically (self-heal) or shows up as drift that the next sync
+wipes out. The correct way to change a managed resource is to commit the change to
+Git and let ArgoCD apply it.
+
+---
+
+## Task 2 — Rollback via GitOps
+
+### Bad deploy — `argocd app get` showing Degraded
+
+```
+<!-- BAD_ARGOCD -->
+```
+
+### `kubectl get pods` showing ImagePullBackOff
+
+```
+<!-- BAD_PODS -->
+```
+
+### `git log --oneline -3` showing deploy + revert
+
+```
+<!-- ROLLBACK_LOG -->
+```
+
+### After `git revert` — `argocd app get` showing Healthy
+
+```
+<!-- GOOD_ARGOCD -->
+```
+
+### How long from `git revert` + push to pods healthy again?
+
+<!-- ROLLBACK_TIME -->
+
+---
+
+## Bonus Task — Automated Image Tag Update
+
+The CI workflow (`.github/workflows/ci.yml`) builds each image tagged with the
+commit SHA, then rewrites the `image:` tag in `k8s/*.yaml` to that SHA and pushes
+a `ci: update image tags to <sha>` commit back to the branch. A guard
+(`if: "!startsWith(github.event.head_commit.message, 'ci:')"`) prevents the
+CI-authored commit from re-triggering the workflow (an infinite loop). ArgoCD then
+syncs the auto-updated tag with no human intervention.
+
+### Git log showing: code commit → CI tag-update commit
+
+```
+<!-- BONUS_LOG -->
+```
+
+### ArgoCD syncing the auto-updated tag
+
+```
+<!-- BONUS_SYNC -->
+```


### PR DESCRIPTION
## Lab 5 — CI/CD & GitOps

Implements a GitHub Actions CI pipeline that builds and pushes all three
QuickTicket service images to ghcr.io, plus ArgoCD-driven GitOps deployment.

### Deliverables
- `.github/workflows/ci.yml` — builds + pushes `gateway`/`events`/`payments` to
  `ghcr.io/jakefish18/quickticket-*` (tagged with the commit SHA and `latest`),
  then auto-updates the image tags in `k8s/*.yaml` and commits them back (bonus).
- `k8s/*.yaml` — switched to ghcr.io images with `imagePullPolicy: Always`.
- `submissions/lab5.md` — full proof of work.

### Results
- ✅ **Task 1** — CI green, 3 images public on ghcr.io, ArgoCD installed, App
  `quickticket` tracking `k8s/` on this branch = **Synced + Healthy**, a
  `version: v2` label change propagated to the cluster via GitOps.
- ✅ **Task 2** — broken image tag → ArgoCD `Progressing` + `ImagePullBackOff`,
  recovered with `git revert` (~6s via `argocd app sync`).
- ✅ **Bonus** — CI auto-updates image tags and commits them; a `ci:`-prefixed
  commit is skipped (no infinite loop); ArgoCD syncs the auto-tagged image.

PR checklist:
- [x] Task 1 done — CI pipeline + ArgoCD deployed + GitOps loop verified
- [x] Task 2 done — rollback via git revert
- [x] Bonus Task done — automated image tag update

> Note: to keep `main` clean, the CI workflow also triggers on `feature/lab5` and
> the ArgoCD Application tracks the `feature/lab5` revision; GitOps mechanics are
> identical to tracking `main`.
