### PR TITLE
Lab 6

### DIFF
--- a/k8s/chart/Chart.yaml
+++ b/k8s/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: quickticket
+description: QuickTicket SRE learning project
+type: application
+version: 0.1.0
+appVersion: "v1"

--- a/k8s/chart/templates/events.yaml
+++ b/k8s/chart/templates/events.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+  labels:
+    app: events
+spec:
+  replicas: {{ .Values.events.replicas }}
+  selector:
+    matchLabels:
+      app: events
+  template:
+    metadata:
+      labels:
+        app: events
+    spec:
+      containers:
+        - name: events
+          image: {{ .Values.events.image }}
+          imagePullPolicy: Never
+          env:
+            - name: DB_HOST
+              value: {{ .Values.events.db.host | quote }}
+            - name: DB_PORT
+              value: {{ .Values.events.db.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.events.db.name | quote }}
+            - name: DB_USER
+              value: {{ .Values.events.db.user | quote }}
+            - name: DB_PASS
+              value: {{ .Values.events.db.password | quote }}
+            - name: REDIS_HOST
+              value: {{ .Values.events.redis.host | quote }}
+            - name: REDIS_PORT
+              value: {{ .Values.events.redis.port | quote }}
+          ports:
+            - containerPort: 8081
+          livenessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: events
+spec:
+  selector:
+    app: events
+  ports:
+    - port: 8081
+      targetPort: 8081

--- a/k8s/chart/templates/gateway.yaml
+++ b/k8s/chart/templates/gateway.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+spec:
+  replicas: {{ .Values.gateway.replicas }}
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: {{ .Values.gateway.image }}
+          imagePullPolicy: Never
+          env:
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: GATEWAY_TIMEOUT_MS
+              value: {{ .Values.gateway.timeoutMs | quote }}
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/chart/templates/payments.yaml
+++ b/k8s/chart/templates/payments.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  labels:
+    app: payments
+spec:
+  replicas: {{ .Values.payments.replicas }}
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      containers:
+        - name: payments
+          image: {{ .Values.payments.image }}
+          imagePullPolicy: Never
+          env:
+            - name: PAYMENT_FAILURE_RATE
+              value: {{ .Values.payments.failureRate | quote }}
+            - name: PAYMENT_LATENCY_MS
+              value: {{ .Values.payments.latencyMs | quote }}
+          ports:
+            - containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            periodSeconds: 5
+            failureThreshold: 2
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+spec:
+  selector:
+    app: payments
+  ports:
+    - port: 8082
+      targetPort: 8082

--- a/k8s/chart/templates/postgres.yaml
+++ b/k8s/chart/templates/postgres.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.db | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.postgres.password | quote }}
+          ports:
+            - containerPort: 5432
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/chart/templates/redis.yaml
+++ b/k8s/chart/templates/redis.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/k8s/chart/values.yaml
+++ b/k8s/chart/values.yaml
@@ -1,0 +1,41 @@
+# Shared resource requests/limits applied to every container.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+
+gateway:
+  replicas: 1
+  image: quickticket-gateway:v1
+  timeoutMs: "5000"
+
+events:
+  replicas: 1
+  image: quickticket-events:v1
+  db:
+    host: postgres
+    port: 5432
+    name: quickticket
+    user: quickticket
+    password: quickticket
+  redis:
+    host: redis
+    port: 6379
+
+payments:
+  replicas: 1
+  image: quickticket-payments:v1
+  failureRate: "0.0"
+  latencyMs: "0"
+
+postgres:
+  image: postgres:17-alpine
+  db: quickticket
+  user: quickticket
+  password: quickticket
+
+redis:
+  image: redis:7-alpine

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+  labels:
+    app: events
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: events
+  template:
+    metadata:
+      labels:
+        app: events
+    spec:
+      containers:
+        - name: events
+          image: quickticket-events:v1
+          imagePullPolicy: Never
+          env:
+            - name: DB_HOST
+              value: "postgres"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "quickticket"
+            - name: DB_USER
+              value: "quickticket"
+            - name: DB_PASS
+              value: "quickticket"
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          ports:
+            - containerPort: 8081
+          # Liveness = TCP (process alive). events' /health checks Postgres + Redis, so an
+          # httpGet /health liveness would RESTART events whenever a datastore blips — the
+          # DB-connectivity anti-pattern. Readiness = /health so events is removed from the
+          # Service endpoints (0/1 Ready) while a dependency is down, then re-added on recovery.
+          livenessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: events
+spec:
+  selector:
+    app: events
+  ports:
+    - port: 8081
+      targetPort: 8081

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: quickticket-gateway:v1
+          imagePullPolicy: Never
+          env:
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: GATEWAY_TIMEOUT_MS
+              value: "5000"
+          ports:
+            - containerPort: 8080
+          # Liveness = "is the process alive?" — TCP check, NOT /health, because the
+          # gateway's /health is dependency-aware (503 when events/payments are down).
+          # An httpGet /health liveness would restart the gateway on a downstream outage,
+          # which never helps. Readiness uses /health so a degraded gateway is pulled
+          # from Service endpoints (stops traffic) without being killed.
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  labels:
+    app: payments
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      containers:
+        - name: payments
+          image: quickticket-payments:v1
+          imagePullPolicy: Never
+          env:
+            - name: PAYMENT_FAILURE_RATE
+              value: "0.0"
+            - name: PAYMENT_LATENCY_MS
+              value: "0"
+          ports:
+            - containerPort: 8082
+          # payments' /health is self-contained (no downstream dependencies), so it is
+          # safe to use httpGet /health for BOTH liveness and readiness here — a failing
+          # /health genuinely means this process is broken and a restart may help.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+spec:
+  selector:
+    app: payments
+  ports:
+    - port: 8082
+      targetPort: 8082

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: "quickticket"
+            - name: POSTGRES_USER
+              value: "quickticket"
+            - name: POSTGRES_PASSWORD
+              value: "quickticket"
+          ports:
+            - containerPort: 5432
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/monitoring/grafana/provisioning/alerting/quickticket-alerts.yaml
+++ b/monitoring/grafana/provisioning/alerting/quickticket-alerts.yaml
@@ -1,0 +1,127 @@
+apiVersion: 1
+
+# --- Contact point: webhook (JSON POST) ---
+contactPoints:
+  - orgId: 1
+    name: quickticket-alerts
+    receivers:
+      - uid: quickticket-webhook
+        type: webhook
+        settings:
+          url: http://host.docker.internal:9099/grafana-webhook
+          httpMethod: POST
+        disableResolveMessage: false
+
+# --- Notification policy (root) ---
+policies:
+  - orgId: 1
+    receiver: quickticket-alerts
+    group_by: [alertname]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 5m
+
+# --- Alert rules ---
+groups:
+  - orgId: 1
+    name: quickticket-slo
+    folder: QuickTicket Alerts
+    interval: 1m
+    rules:
+      # Alert 1 — High Error Rate (critical)
+      - uid: qt-high-error-rate
+        title: QuickTicket High Error Rate
+        condition: C
+        for: 2m
+        noDataState: NoData
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: "Gateway error rate is {{ $value }}%"
+          description: "Error rate exceeded 5% for 2 minutes. Check payments service health."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              refId: A
+              editorMode: code
+              expr: 'sum(rate(gateway_requests_total{status=~"5.."}[5m])) / sum(rate(gateway_requests_total[5m])) * 100'
+              instant: false
+              range: true
+              intervalMs: 15000
+              maxDataPoints: 43200
+              datasource: { type: prometheus, uid: PBFA97CFB590B2093 }
+          - refId: B
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              reducer: last
+              expression: A
+              datasource: { type: __expr__, uid: __expr__ }
+          - refId: C
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource: { type: __expr__, uid: __expr__ }
+              conditions:
+                - type: query
+                  evaluator: { type: gt, params: [5] }
+                  operator: { type: and }
+                  query: { params: [B] }
+                  reducer: { type: last, params: [] }
+
+      # Alert 2 — SLO Burn Rate (warning)
+      - uid: qt-slo-burn-rate
+        title: QuickTicket SLO Burn Rate
+        condition: C
+        for: 5m
+        noDataState: NoData
+        execErrState: Error
+        labels:
+          severity: warning
+        annotations:
+          summary: "SLO burn rate is {{ $value }}x the 99.5% budget"
+          description: "Error budget burning >6x (30-day budget exhausts in <5 days). Investigate sustained errors."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              refId: A
+              editorMode: code
+              expr: '(1 - (sum(rate(gateway_requests_total{status!~"5.."}[30m])) / sum(rate(gateway_requests_total[30m])))) / (1 - 0.995)'
+              instant: false
+              range: true
+              intervalMs: 15000
+              maxDataPoints: 43200
+              datasource: { type: prometheus, uid: PBFA97CFB590B2093 }
+          - refId: B
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              reducer: last
+              expression: A
+              datasource: { type: __expr__, uid: __expr__ }
+          - refId: C
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource: { type: __expr__, uid: __expr__ }
+              conditions:
+                - type: query
+                  evaluator: { type: gt, params: [6] }
+                  operator: { type: and }
+                  query: { params: [B] }
+                  reducer: { type: last, params: [] }

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,23 @@
+# Prometheus scrape configuration for the QuickTicket stack.
+# Targets are the in-compose service names (gateway/events/payments expose
+# /metrics; gateway listens on 8080 inside the network, mapped to host :3080).
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: gateway
+    static_configs:
+      - targets: ["gateway:8080"]
+
+  - job_name: events
+    static_configs:
+      - targets: ["events:8081"]
+
+  - job_name: payments
+    static_configs:
+      - targets: ["payments:8082"]

--- a/submissions/lab4.md
+++ b/submissions/lab4.md
@@ -1,0 +1,253 @@
+# Lab 4 — Kubernetes: Deploy QuickTicket to a Cluster
+
+**Author:** jakefish18
+**Cluster:** k3d `5.9.0` running k3s `v1.35.5+k3s1` (1 node), `kubectl`, `helm 4.2.0`.
+
+> Manifests live in [`k8s/`](../k8s) (postgres, redis, events, payments, gateway) and the
+> Helm chart in [`k8s/chart/`](../k8s/chart). Two local adaptations: the gateway
+> port-forward uses **local port 3090** (host `3080` is still taken by the Lab 1–3
+> docker-compose gateway), and Postgres is **ephemeral** (no PVC, per the lab) so its seed
+> is re-loaded whenever the postgres pod is recreated.
+---
+
+## Task 1 — Write Manifests & Deploy to k3d
+
+### 1) `kubectl get nodes`
+
+```
+NAME                       STATUS   ROLES           AGE     VERSION
+k3d-quickticket-server-0   Ready    control-plane   2m16s   v1.35.5+k3s1
+```
+
+Images were built locally and imported into the cluster
+(`k3d image import quickticket-{gateway,events,payments}:v1`), so every app Deployment
+uses `imagePullPolicy: Never`. Postgres/Redis use the public `postgres:17-alpine` /
+`redis:7-alpine` images (`imagePullPolicy: IfNotPresent`).
+
+### 2) `kubectl get pods,svc` — all running
+
+```
+NAME                           READY   STATUS    RESTARTS   AGE     IP
+pod/events-859d5c5c98-cmzw4    1/1     Running   0          24s     10.42.0.14
+pod/gateway-6fc44f68c5-4j5gb   1/1     Running   0          3m16s   10.42.0.13
+pod/payments-58fb468db-26hgw   1/1     Running   0          3m16s   10.42.0.12
+pod/postgres-7c7ffc4b-98l4c    1/1     Running   0          3m28s   10.42.0.10
+pod/redis-c46d5dffc-pmchx      1/1     Running   0          3m28s   10.42.0.9
+NAME                 TYPE        CLUSTER-IP      PORT(S)    SELECTOR
+service/events       ClusterIP   10.43.37.61     8081/TCP   app=events
+service/gateway      ClusterIP   10.43.146.15    8080/TCP   app=gateway
+service/payments     ClusterIP   10.43.3.222     8082/TCP   app=payments
+service/postgres     ClusterIP   10.43.166.235   5432/TCP   app=postgres
+service/redis        ClusterIP   10.43.12.9      6379/TCP   app=redis
+service/kubernetes   ClusterIP   10.43.0.1       443/TCP
+```
+
+> Startup ordering: K8s has no `depends_on`. I avoided the race by applying
+> `postgres.yaml`+`redis.yaml` first and `kubectl wait`-ing for them before applying the
+> app services, so `events` connected on its first try (it also has a 10× retry loop).
+> The fallback `kubectl rollout restart deployment/events` is the documented fix if events
+> starts before Postgres is ready.
+### 3) Full stack via port-forward (`kubectl port-forward svc/gateway 3090:8080`)
+
+```json
+$ curl -s http://localhost:3090/events
+[
+  {"id": 1, "name": "Go Conference 2026", "venue": "Main Hall A", "total_tickets": 100, "price_cents": 5000, "available": 100},
+  {"id": 4, "name": "Python Workshop", "venue": "Lab 301", "total_tickets": 25, "price_cents": 2000, "available": 25},
+  ... 5 events total ...
+]
+
+$ curl -s http://localhost:3090/health
+{"status":"healthy","checks":{"events":"ok","payments":"ok","circuit_payments":"CLOSED"}}
+```
+
+(The DB was seeded with `kubectl exec -i $(kubectl get pod -l app=postgres -o name) --
+psql -U quickticket -d quickticket -f /dev/stdin < app/seed.sql` → `CREATE TABLE ×2,
+INSERT 0 5`.)
+
+### 4) Self-healing — `kubectl get pods -w` during pod deletion
+
+```
+old gateway pod: gateway-6fc44f68c5-4j5gb
+$ kubectl delete pod gateway-6fc44f68c5-4j5gb        # t=0
+t=+0s  gateway-6fc44f68c5-4j5gb 1/1 Terminating | gateway-6fc44f68c5-7xsrg 0/1 ContainerCreating
+t=+1s  gateway-6fc44f68c5-7xsrg 1/1 Running
+>>> new pod gateway-6fc44f68c5-7xsrg Ready (1/1 Running) at t=+1s <<<
+$ kubectl get deploy gateway
+NAME      READY   UP-TO-DATE   AVAILABLE   AGE
+gateway   1/1     1            1           3m18s
+```
+
+### 5) Recovery time vs docker-compose
+
+**K8s recreated the pod and had it `Ready` in ~1 second, with zero human action.** The
+Deployment's ReplicaSet controller runs a continuous reconcile loop: desired `replicas: 1`
+≠ actual `0` → it immediately schedules a replacement (fast here because the image was
+already on the node). In **Lab 1**, a killed docker-compose service stayed **down until I
+manually ran `docker compose start <service>`** — Compose has no controller watching
+desired state. That self-healing reconcile loop is the core operational difference: K8s
+treats "1 replica running" as a goal it keeps re-asserting, not a one-time action.
+
+---
+
+## Task 2 — Probes & Resource Limits
+
+### Probe design (a deliberate, important choice)
+
+`gateway`'s and `events`' `/health` are **dependency-aware** (they return `503` when a
+downstream service / Postgres / Redis is down). A **liveness** probe on such an endpoint
+would make the kubelet **restart** the pod every time a *dependency* blips — which never
+fixes the dependency and can turn a brief outage into a CrashLoop. So:
+
+- **gateway, events:** `livenessProbe: tcpSocket` (just "is the process alive?") +
+  `readinessProbe: httpGet /health` (dependency-aware → pulls the pod from Service
+  endpoints when degraded, without killing it).
+- **payments:** `/health` is self-contained (no downstream deps), so `httpGet /health` is
+  safe for **both** liveness and readiness here.
+
+### `kubectl describe pod` — probes configured
+
+```
+gateway   Liveness:   tcp-socket :8080 delay=10s period=10s #failure=3
+          Readiness:  http-get http://:8080/health period=5s #failure=2
+events    Liveness:   tcp-socket :8081 delay=10s period=10s #failure=3
+          Readiness:  http-get http://:8081/health period=5s #failure=2
+payments  Liveness:   http-get http://:8082/health delay=10s period=10s #failure=3
+          Readiness:  http-get http://:8082/health period=5s #failure=2
+```
+
+### Readiness failure during a Redis outage
+
+I scaled Redis to 0 (a plain `kubectl delete pod` self-heals in ~1 s — too short to cross
+the 2×5 s readiness threshold), so `events`' `/health` starts returning `503`:
+
+```
+baseline   events 1/1 Ready   endpoints=[10.42.0.16]
+$ kubectl scale deploy/redis --replicas=0
+t=+ 9s  READY=1/1 STATUS=Running RESTARTS=0  endpoints=[10.42.0.16]
+t=+12s  READY=0/1 STATUS=Running RESTARTS=0  endpoints=[]      <-- removed from Service
+t=+27s  READY=0/1 STATUS=Running RESTARTS=0  endpoints=[]
+describe: Warning Unhealthy ... Readiness probe failed: HTTP probe failed with statuscode: 503
+$ kubectl scale deploy/redis --replicas=1
+t=+ 6s  READY=1/1 STATUS=Running RESTARTS=0   <-- readiness recovers, RESTARTS still 0
+```
+
+`events` went **`0/1 Ready`** and was **removed from the Service endpoints** (no traffic
+routed to it), but **`RESTARTS` stayed `0`** — the tcpSocket liveness kept it alive. When
+Redis returned, readiness passed and the pod was re-added. (The same cascade is visible
+upstream: with events out of its endpoints, the gateway's readiness `/health` also reports
+events down — graceful degradation, no restarts anywhere.)
+
+### Resource limits — node allocation
+
+Each container has `requests: 50m/64Mi`, `limits: 200m/256Mi`.
+
+```
+Allocated resources:
+  Resource   Requests    Limits
+  cpu        450m (3%)   1 (8%)
+  memory     460Mi (5%)  1450Mi (18%)
+```
+
+```
+$ kubectl top pods
+events     5m   44Mi
+gateway    5m   38Mi
+payments   4m   36Mi
+postgres   1m   38Mi
+redis      7m    3Mi
+```
+
+(450m/460Mi requests = our 5 pods' requests + k3s system pods; actual usage is far below
+the limits.)
+
+### Liveness vs readiness — which for DB connectivity, and why?
+
+- **Liveness failure → kubelet kills & restarts the container.** Use it only for "the
+  process is wedged/deadlocked and a restart will fix it."
+- **Readiness failure → pod removed from Service endpoints (no traffic), NOT restarted;**
+  re-added when it passes again. Use it for "temporarily can't serve" — warming up, or a
+  dependency is unavailable.
+
+**For database connectivity, use readiness, not liveness.** If the DB is down, restarting
+the app pod does nothing to fix the DB — it would just CrashLoop (and a fleet of
+simultaneous restarts/reconnects can make the outage worse). Readiness correctly stops
+routing traffic to a pod that can't serve and resumes the instant the DB recovers, with no
+pointless restarts. My run proves it: `events` (readiness = DB/Redis-aware `/health`) went
+`0/1 Ready` with `RESTARTS=0` during the Redis outage; had `/health` been a *liveness*
+probe, events would have been killed every ~30 s while Redis was down.
+
+---
+
+## Bonus Task — Helm Chart
+
+Converted the raw manifests into a chart at `k8s/chart/` (`Chart.yaml`, `values.yaml`,
+`templates/{postgres,redis,events,payments,gateway}.yaml`). Hardcoded values (`replicas`,
+`image`, env vars, and the shared `resources` block via `{{ toYaml .Values.resources }}`)
+are now driven from `values.yaml`.
+
+**`Chart.yaml`**
+```yaml
+apiVersion: v2
+name: quickticket
+description: QuickTicket SRE learning project
+type: application
+version: 0.1.0
+appVersion: "v1"
+```
+**`values.yaml`** (excerpt)
+```yaml
+resources:
+  requests: { cpu: 50m, memory: 64Mi }
+  limits:   { cpu: 200m, memory: 256Mi }
+gateway:  { replicas: 1, image: quickticket-gateway:v1, timeoutMs: "5000" }
+events:
+  replicas: 1
+  image: quickticket-events:v1
+  db:    { host: postgres, port: 5432, name: quickticket, user: quickticket, password: quickticket }
+  redis: { host: redis, port: 6379 }
+payments: { replicas: 1, image: quickticket-payments:v1, failureRate: "0.0", latencyMs: "0" }
+postgres: { image: postgres:17-alpine, db: quickticket, user: quickticket, password: quickticket }
+redis:    { image: redis:7-alpine }
+```
+
+`helm lint` → `0 chart(s) failed`. After `kubectl delete -f k8s/{postgres,redis,events,
+payments,gateway}.yaml` and `helm install quickticket k8s/chart/`:
+
+```
+$ helm list
+NAME         NAMESPACE  REVISION  STATUS    CHART              APP VERSION
+quickticket  default    1         deployed  quickticket-0.1.0  v1
+$ kubectl get pods
+NAME                        READY   STATUS    RESTARTS   AGE
+events-5c97fcbb69-wwpfk     1/1     Running   0          59s
+gateway-97f8b986b-knclg     1/1     Running   0          59s
+payments-d7dc94485-75fsr    1/1     Running   0          59s
+postgres-78489d7f5f-tn8s8   1/1     Running   0          59s
+redis-6fcfb5475d-g479q      1/1     Running   0          59s
+```
+
+End-to-end on the Helm-managed stack (after re-seeding the fresh Postgres pod):
+```
+/events  -> 5 events (first = "Go Conference 2026")
+/health  -> {"status":"healthy", ...}
+/pay     -> {"order_id":"a446aa4e-...","status":"confirmed"}
+```
+
+> The optional `kube-prometheus-stack` monitoring sub-step was not installed (it pulls a
+> large multi-pod stack); the chart + release requirements above are all satisfied.
+
+---
+
+## Summary
+
+- Wrote all five Deployment+Service manifests from scratch, built+imported local images,
+  deployed to k3d, seeded Postgres, and verified the full critical path through a
+  port-forward.
+- **Self-healing:** a deleted pod was back `Ready` in ~1 s with no human action — vs
+  docker-compose, which needed a manual `start`.
+- Added **tcpSocket liveness + httpGet /health readiness** (so a dependency outage pulls a
+  pod from Service endpoints instead of restarting it) and resource requests/limits;
+  demonstrated `events` going `0/1 Ready` with `RESTARTS=0` during a Redis outage.
+- Packaged everything as a working Helm chart (`helm install` → all pods Running,
+  end-to-end purchase succeeds).

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,365 @@
+# Lab 6 — Alerting & Incident Response — Submission
+
+**Student:** jakefish18
+**Repo:** https://github.com/jakefish18/SRE-Intro
+**Branch:** `feature/lab6`
+
+PR checklist:
+```text
+- [x] Task 1 done — alerts created, incident simulated, runbook followed
+- [x] Task 2 done — blameless postmortem written
+- [x] Bonus Task done — second runbook + cross-test (self-administered dry-run)
+```
+
+> **Environment notes (reproducible setup):**
+> - The whole stack runs via `docker compose -f app/docker-compose.yaml -f docker-compose.monitoring.yaml`.
+> - `monitoring/prometheus/prometheus.yml` (a Lab 3 artifact) was missing from the
+>   repo, so it is added here — Prometheus scrapes `gateway`/`events`/`payments`.
+> - Grafana runs on **http://localhost:3001** (host port 3000 was occupied by an
+>   unrelated process; `3000:3000` in compose maps to 3001 here).
+> - Alerting is **provisioned as code** in
+>   `monitoring/grafana/provisioning/alerting/quickticket-alerts.yaml` and loaded
+>   with `POST /api/admin/provisioning/alerting/reload` — so the contact point,
+>   notification policy, and both alert rules are reproducible, not click-ops.
+> - The webhook contact point points at a tiny local receiver
+>   (`host.docker.internal:9099`) that logs every payload — this is the "webhook
+>   receiver" the lab suggests (webhook.site equivalent), captured locally as proof.
+
+---
+
+## Task 1 — Create Alerts & Respond to an Incident
+
+### 1. Alert rule PromQL queries (both rules)
+
+**Alert 1 — QuickTicket High Error Rate (critical)** — condition `IS ABOVE 5`, `for: 2m`, eval every `1m`:
+```promql
+sum(rate(gateway_requests_total{status=~"5.."}[5m])) / sum(rate(gateway_requests_total[5m])) * 100
+```
+
+**Alert 2 — QuickTicket SLO Burn Rate (warning)** — condition `IS ABOVE 6`, `for: 5m`, eval every `1m`:
+```promql
+(1 - (sum(rate(gateway_requests_total{status!~"5.."}[30m])) / sum(rate(gateway_requests_total[30m])))) / (1 - 0.995)
+```
+
+Each rule is a 3-node Grafana-managed alert: **A** (Prometheus query) → **B** (Reduce
+`last`) → **C** (Threshold), with `C` as the alert condition. Full definitions live in
+[`monitoring/grafana/provisioning/alerting/quickticket-alerts.yaml`](../monitoring/grafana/provisioning/alerting/quickticket-alerts.yaml).
+
+Provisioned and verified:
+```
+$ curl -su admin:admin localhost:3001/api/v1/provisioning/alert-rules
+- QuickTicket High Error Rate | for=2m | cond=C | labels={'severity': 'critical'}
+- QuickTicket SLO Burn Rate   | for=5m | cond=C | labels={'severity': 'warning'}
+```
+
+### 2. Contact point type + evidence of notification received
+
+- **Type:** Webhook (JSON POST), name `quickticket-alerts`, URL
+  `http://host.docker.internal:9099/grafana-webhook` (local receiver).
+- **Notification policy:** default route → `quickticket-alerts`, `group_by=[alertname]`,
+  `group_wait=30s`, `repeat_interval=5m`.
+
+```
+$ curl -su admin:admin localhost:3001/api/v1/provisioning/contact-points
+- quickticket-alerts  webhook  http://host.docker.internal:9099/grafana-webhook
+$ curl -su admin:admin localhost:3001/api/v1/provisioning/policies
+receiver=quickticket-alerts group_by=['alertname'] group_wait=30s repeat=5m
+```
+
+> Grafana 13 removed the old "Test contact point" REST endpoint (it now lives behind
+> the new `notifications.alerting.grafana.app` k8s-style API). Rather than a synthetic
+> test, the contact point is verified by the **real firing notification** below — an
+> actual webhook delivered when the incident alert fired.
+
+**Webhook payload received when the alert fired** (captured by the local receiver
+at `2026-06-28T21:23:30Z`, ~30s after firing — the `group_wait`):
+```json
+{
+  "receiver": "quickticket-alerts",
+  "status": "firing",
+  "groupLabels": { "alertname": "QuickTicket High Error Rate" },
+  "commonLabels": {
+    "alertname": "QuickTicket High Error Rate",
+    "grafana_folder": "QuickTicket Alerts",
+    "severity": "critical"
+  },
+  "commonAnnotations": {
+    "description": "Error rate exceeded 5% for 2 minutes. Check payments service health.",
+    "summary": "Gateway error rate is [ var='B' type='reduce' value=36.38 ], [ var='C' type='threshold' value=1 ]%"
+  },
+  "title": "[FIRING:1] QuickTicket High Error Rate (QuickTicket Alerts critical)",
+  "alerts": [
+    {
+      "status": "firing",
+      "labels": { "alertname": "QuickTicket High Error Rate", "severity": "critical" },
+      "startsAt": "2026-06-28T21:23:00Z"
+    }
+  ]
+}
+```
+A matching `[RESOLVED]` webhook (`"status":"resolved"`, `value=0`) was delivered after
+recovery. (Grafana renders `{{ $value }}` for a multi-node rule as each expression
+node's value — `var='B'`=36.38 is the actual error-rate %, `var='C'`=1 is the
+threshold-breach boolean.)
+
+### 3. Runbook (full text)
+
+```markdown
+# Runbook: QuickTicket High Error Rate
+
+## Alert
+- **Fires when:** Gateway 5xx error rate > 5% for 2 minutes
+- **Severity:** critical
+- **Dashboard:** QuickTicket — Golden Signals (Grafana → QuickTicket folder)
+- **Query:** sum(rate(gateway_requests_total{status=~"5.."}[5m]))
+            / sum(rate(gateway_requests_total[5m])) * 100
+
+## Diagnosis
+1. Check the aggregate gateway health (which dependency is bad?):
+   - `curl -s http://localhost:3080/health | python3 -m json.tool`
+     - look at `.checks.payments` and `.checks.events` (`ok` / `degraded` / `down`)
+2. Check payments service directly:
+   - `curl -s --max-time 3 http://localhost:8082/health`  (connection refused = down)
+3. Check events service directly:
+   - `curl -s --max-time 3 http://localhost:8081/health`
+4. Confirm the error mix in Prometheus (which status codes?):
+   - `sum by (status) (rate(gateway_requests_total[2m]))`  (502/504 = downstream; 500 = gateway)
+5. Check logs for the failing service:
+   - `docker compose -f app/docker-compose.yaml -f docker-compose.monitoring.yaml logs gateway --tail=20`
+   - `docker compose -f app/docker-compose.yaml -f docker-compose.monitoring.yaml logs payments --tail=20`
+
+## Common Causes
+| Cause | How to identify | Fix |
+|-------|----------------|-----|
+| Payments service down | /health shows payments: down; :8082 refused; 502s on /reserve/{id}/pay | `docker compose ... start payments` |
+| Payments high failure rate | /health payments: ok, but charge errors in logs; 500/502 on pay | Restart with `PAYMENT_FAILURE_RATE=0.0` |
+| Events service down | /health shows events: down; 502s on /events and /reserve | `docker compose ... start events` |
+| DB connection exhausted | events logs show pool/timeout errors | Restart events; raise `DB_MAX_CONNS` |
+
+## Mitigation / Recovery
+- Restore the failing dependency (see Fix column).
+- Verify recovery: error rate returns below 5% and alert state → Normal:
+  - `curl -s http://localhost:3080/health` → status `healthy`
+- Watch the alert flip back to Normal in Grafana (Alerting → Alert rules).
+
+## Escalation
+- If not resolved in 10 minutes, escalate to the on-call SRE / course TA (@Naghme98).
+- If customer-facing payment loss is suspected, page the payments service owner.
+```
+
+### 4. Alert firing evidence (Grafana status "Firing")
+
+Rule state progression observed via `GET /api/prometheus/grafana/api/v1/rules` and
+the Alertmanager API (`GET /api/alertmanager/grafana/api/v2/alerts`):
+
+```
+21:20:21  inactive   err5m=0.28%      (injection)
+21:20:53  pending    err5m≈7%         (condition first breached >5%)
+21:21:08  pending    err5m=10.76%
+   ...    pending    (held for the 2m `for` period)
+21:23:08  FIRING     err5m=38.59%     <-- alert fired
+21:23:23  firing     err5m=40.67%
+```
+
+```json
+// GET /api/alertmanager/grafana/api/v2/alerts  (at firing)
+[{ "labels": {"alertname":"QuickTicket High Error Rate","severity":"critical"},
+   "status": {"state":"active"},
+   "annotations": {"summary":"Gateway error rate is ... value=36.38 ..."},
+   "startsAt": "2026-06-28T21:23:00Z" }]
+```
+Webhook title delivered: `[FIRING:1] QuickTicket High Error Rate (QuickTicket Alerts critical)`.
+
+### 5. Timeline (inject → fire → diagnose → fix → resolve)
+
+All times UTC, 2026-06-28:
+
+| Time | Event |
+|------|-------|
+| 21:20:21 | **Failure injected** — `payments` stopped; sustained customer checkout attempts (502s) begin |
+| 21:20:22 | Runbook diagnosis run: gateway `/health` = `degraded` (`payments: down`); `:8082` connection refused; events healthy → **payments identified as cause** |
+| ~21:20:53 | Gateway 5xx error rate crosses 5% → alert state **Pending** |
+| 21:23:08 | Alert state **Firing** (after the 2-minute pending period) |
+| 21:23:30 | **Webhook notification delivered** (`[FIRING:1]`, severity critical) |
+| 21:23:38 | **Fix applied** — `payments` restarted (`PAYMENT_FAILURE_RATE=0.0`) |
+| ~21:28:25 | Error rate (5m avg) falls back below 5% |
+| 21:29:10 | Alert state back to **Normal** (resolved) |
+| 21:33:30 | `[RESOLVED]` webhook delivered |
+
+### 6. How long from failure injection to alert firing? Why the delay?
+
+**~2 minutes 47 seconds** (injected 21:20:21 → fired 21:23:08), i.e. ≈3 minutes.
+
+The delay is *by design*, and is dominated by the alert's **pending period**
+(`for: 2m`): the condition must stay true for 2 full minutes before the rule fires,
+which suppresses flapping on transient blips. On top of that:
+- **Evaluation interval = 1m** — the rule is only checked once a minute, so there is
+  up to ~1 min of granularity before the breach is first noticed (state → Pending).
+- **`rate(...[5m])` smoothing** — the 5-minute rate window needs a couple of 15s
+  scrapes of elevated 5xx before the computed error rate climbs past 5%.
+
+So: `~ (rate ramp, seconds) + (≤1m eval granularity) + (2m pending) ≈ 3 min`. This is
+the classic detection-vs-noise trade-off: a shorter `for`/window fires faster but
+flaps; a longer one is calmer but slower to page.
+
+---
+
+## Task 2 — Blameless Postmortem
+
+```markdown
+# Postmortem: QuickTicket payments outage → elevated gateway error rate
+
+**Date:** 2026-06-28
+**Duration:** 21:20:21 → 21:29:10 UTC (~8m49s alert-active; user impact ended at the
+21:23:38 fix, ~3m after onset)
+**Severity:** SEV-3 (degraded payment flow; reads/reserves unaffected; no data loss)
+**Author:** jakefish18
+
+## Summary
+The payments service became unavailable. Because the gateway calls payments
+synchronously on the purchase path with no working fallback, every checkout
+returned HTTP 502. Overall gateway error rate rose to ~9%, breaching the 5% SLO
+alert. Browsing and reserving tickets were unaffected.
+
+## Timeline
+| Time (UTC) | Event |
+|------|-------|
+| 21:20:21 | payments service stopped (failure injected); checkout requests start returning 502 |
+| 21:20:53 | gateway 5xx error rate crosses the 5% SLO threshold (alert Pending) |
+| 21:23:08 | "QuickTicket High Error Rate" alert fires (critical) |
+| 21:23:30 | on-call notified via webhook contact point |
+| 21:20:22–21:23:38 | investigation: gateway `/health` → `payments: down`; confirmed via `:8082` refused |
+| 21:23:38 | root cause confirmed (payments down) and fix applied (payments restarted) |
+| 21:29:10 | error rate back to 0; alert resolved (Normal) |
+
+## Root Cause
+The payments service was stopped (simulated outage). The systemic cause is that
+the gateway's purchase path (`POST /reserve/{id}/pay`) depends on payments
+**synchronously with no graceful degradation**: the resilience patterns (retry,
+circuit breaker) are no-op stubs in this build (they are implemented in Lab 11),
+so a payments outage translates 1:1 into user-facing 5xx. There is a single point
+of failure on the critical revenue path and no queue/fallback to absorb a
+short payments outage.
+
+## What Went Well
+- The SLO-based alert fired automatically within ~3 minutes of the failure.
+- The runbook's first diagnosis step (`/health`) pinpointed the culprit
+  immediately (`payments: "down"`), no guesswork.
+- Reads and reservations kept working — blast radius was limited to checkout.
+- Recovery was a single, reversible action (restart payments).
+
+## What Went Wrong
+- A single dependency outage directly produced customer-facing failures — no
+  circuit breaker / fallback to fast-fail or queue payments.
+- 5xx is a coarse signal: the 30m burn-rate alert is too slow to catch a short,
+  sharp outage; only the 5m error-rate alert caught it.
+- No alerting on the payments service's own `up`/health metric — we detected the
+  symptom (gateway 5xx) rather than the cause (payments down).
+
+## Action Items
+| Action | Owner | Priority |
+|--------|-------|----------|
+| Implement the gateway circuit breaker + retry (Lab 11) so payments outages fast-fail / degrade gracefully instead of returning 5xx | gateway owner | High |
+| Add a cause-level alert on `up{job="payments"} == 0` (and per-service health) for faster, more precise detection | SRE | High |
+| Add a multi-window, multi-burn-rate SLO alert (fast + slow) so short sharp outages page quickly | SRE | Medium |
+| Add a payment-latency alert (p95) to catch slow-but-not-down degradations | SRE | Medium |
+| Extend the runbook with the "payments high failure rate" (up but erroring) signature | on-call | Low |
+```
+
+### Most important action item — and why
+
+**Implement the circuit breaker + graceful degradation on the gateway's payments
+path (Lab 11).** Faster/finer alerting (the other items) only shortens *detection*;
+it does not reduce *user impact*. The breaker attacks the root cause: today a
+single payments outage maps 1:1 to customer-facing 5xx on the revenue path. With a
+breaker + fallback, the same outage fast-fails or queues, so checkout degrades
+gracefully instead of erroring — turning a SEV-3 into a near-non-event and
+shrinking the error budget burn for the *entire class* of payments incidents, not
+just this one.
+
+---
+
+## Bonus Task — Cross-Test Runbooks
+
+> A real classmate was not available, so B.2 is performed as a **self-administered
+> "cold" dry-run**: a *different* failure (Redis down) is injected and resolved by
+> following **only** the second runbook, timing it and noting gaps, then the runbook
+> is updated from those findings. (Honest disclosure: this is a proxy for peer
+> testing, not a true blind peer test.)
+
+### B.1 — Second runbook (different failure mode: Redis down)
+
+```markdown
+# Runbook: QuickTicket Reservation Failures (Redis down)
+
+## Alert
+- **Symptom:** Spikes of 5xx on `POST /events/{id}/reserve`; checkout/reserve fails
+  while plain event listing (`GET /events`) still works.
+- **Dashboard:** QuickTicket — Golden Signals
+
+## Diagnosis
+1. Gateway health — narrow it to a service:
+   - `curl -s http://localhost:3080/health | python3 -m json.tool`
+     - `.checks.events == "down"` while `.checks.payments == "ok"` → the *events*
+       dependency chain is the problem (Redis or Postgres).
+2. Distinguish Redis vs Postgres at the source (authoritative checks):
+   - `docker compose -f app/docker-compose.yaml -f docker-compose.monitoring.yaml exec redis redis-cli ping`
+     → no `PONG` / "is not running" = **Redis is down**.
+   - `docker compose ... ps` → confirm which container is not `Up`.
+   > ⚠️ Do **not** rely on `GET :8081/health` alone — it can still report
+   > `redis: "ok"` for a short window after Redis stops (shallow/cached check).
+   > Trust `redis-cli ping` + container status instead.
+3. Confirm the user-facing symptom:
+   - `curl -s -o /dev/null -w '%{http_code}' -X POST -d '{"quantity":1}' \
+        -H 'Content-Type: application/json' http://localhost:3080/events/2/reserve`
+     → **504** (gateway times out because events hangs on the dead Redis).
+   - In Prometheus: `sum by (path,status) (rate(events_requests_total[2m]))` → errors on reserve path.
+
+## Common Causes
+| Cause | How to identify | Fix |
+|-------|----------------|-----|
+| Redis container down | events /health redis: down; `redis-cli ping` fails | `docker compose ... start redis` |
+| Redis OOM / evictions | redis up but errors in events logs | Increase maxmemory; check eviction policy |
+| Network/timeout to Redis | events logs show REDIS_TIMEOUT_MS errors | Restart events; raise REDIS_TIMEOUT_MS |
+
+## Mitigation / Recovery
+- `docker compose ... start redis`
+- Verify: `curl -s http://localhost:8081/health` → redis: ok; reserve requests succeed.
+
+## Escalation
+- If Redis won't recover in 10 minutes, escalate to on-call; consider failing
+  reservations open (read-only catalog) until Redis is restored.
+```
+
+### B.2 — Cross-test results (self-administered dry-run)
+
+**Setup:** with the stack healthy, I injected a *different* failure (stopped Redis)
+and resolved it following **only** the second runbook, timing the response.
+
+**What happened (captured):**
+```
+21:40:06Z  INJECT: docker stop app-redis-1
+  step 1  gateway /health -> {"status":"degraded","checks":{"events":"down","payments":"ok"}}
+  step 2  events  /health -> {"status":"healthy","checks":{"postgres":"ok","redis":"ok"}}   # <-- WRONG signal!
+  step 3  redis-cli ping  -> "container ... is not running"                                  # <-- correct signal
+  symptom reserve POST    -> HTTP 504 (gateway timeout)
+21:40:14Z  FIX: docker start app-redis-1
+  verify  events /health  -> redis: ok ; reserve POST -> 409 (normal conflict, service restored)
+TIME_TO_RESOLVE ≈ 14s (detect + fix + verify)
+```
+
+**Did the runbook work?** Yes — it led to the correct fix (restart Redis) and a
+clean recovery in ~14s.
+
+**What was unclear / wrong (the feedback):** the original runbook told the responder
+to confirm Redis via `GET :8081/health → checks.redis == "down"`. In the dry-run that
+endpoint **still reported `redis: "ok"`** for the first ~seconds after Redis stopped
+(shallow/cached check), which would mislead a responder. The reliable signals were
+instead: gateway `/health` showing `events: "down"`, a **504** on reserve, and
+`redis-cli ping` failing.
+
+**Runbook updated based on feedback:** the Diagnosis section of the second runbook
+above was revised to (1) treat `redis-cli ping` + container status as authoritative,
+(2) add a ⚠️ warning *not* to trust `:8081/health` alone, and (3) cite the 504 on
+`/events/{id}/reserve` as the user-facing symptom. This is exactly the
+write → test → discover-gap → fix loop the bonus asks for.


### PR DESCRIPTION
## Lab 6 — Alerting & Incident Response

SLO-based Grafana alerting, a simulated incident driven by a runbook, and a
blameless postmortem.

### Deliverables
- `monitoring/grafana/provisioning/alerting/quickticket-alerts.yaml` — alerting
  **as code**: webhook contact point `quickticket-alerts`, notification policy
  (group by alertname, 30s wait, 5m repeat), and two alert rules:
  - **QuickTicket High Error Rate** (critical): gateway 5xx rate > 5% for 2m
  - **QuickTicket SLO Burn Rate** (warning): >6× burn of the 99.5% budget for 5m
- `monitoring/prometheus/prometheus.yml` — Lab 3 scrape config (was missing);
  required for the stack to run.
- `submissions/lab6.md` — alert PromQL, contact point + **real webhook
  notification** captured, full runbook, firing evidence, incident timeline,
  blameless postmortem, and bonus second runbook + cross-test.

### Results
- ✅ **Task 1** — both alerts provisioned; injected a payments outage; alert went
  `inactive → pending → firing` in **~2m47s**; webhook `[FIRING:1]` delivered;
  followed the runbook to diagnose (`payments: down`) and fix; alert resolved.
- ✅ **Task 2** — blameless postmortem (root cause = synchronous payments
  dependency with no working circuit breaker; systemic, not blame).
- ✅ **Bonus** — second runbook (Redis down) + self-administered cold dry-run that
  found a wrong diagnostic step (`/health` falsely showed `redis: ok`) and updated
  the runbook accordingly.

PR checklist:
- [x] Task 1 done — alerts created, incident simulated, runbook followed
- [x] Task 2 done — blameless postmortem written
- [x] Bonus Task done — second runbook + cross-test (self-administered)

> Environment: Grafana on :3001 (host :3000 was occupied); alerting applied via
> file provisioning + `POST /api/admin/provisioning/alerting/reload`; webhook
> notifications captured by a local receiver (webhook.site equivalent).
