### PR TITLE
feat(lab11): notifications service and resilience patterns

### DIFF
--- a/app/docker-compose.yaml
+++ b/app/docker-compose.yaml
@@ -6,10 +6,12 @@ services:
     environment:
       - EVENTS_URL=http://events:8081
       - PAYMENTS_URL=http://payments:8082
+      - NOTIFICATIONS_URL=http://notifications:8083
       - GATEWAY_TIMEOUT_MS=5000
     depends_on:
       - events
       - payments
+      - notifications
 
   events:
     build: ./events
@@ -39,6 +41,14 @@ services:
     environment:
       - PAYMENT_FAILURE_RATE=${PAYMENT_FAILURE_RATE:-0.0}
       - PAYMENT_LATENCY_MS=${PAYMENT_LATENCY_MS:-0}
+
+  notifications:
+    build: ./notifications
+    ports:
+      - "8083:8083"
+    environment:
+      - NOTIFY_FAILURE_RATE=${NOTIFY_FAILURE_RATE:-0.0}
+      - NOTIFY_LATENCY_MS=${NOTIFY_LATENCY_MS:-0}
 
   postgres:
     image: postgres:17-alpine

--- a/app/gateway/main.py
+++ b/app/gateway/main.py
@@ -24,7 +24,7 @@ from collections import defaultdict, deque
 import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
-from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # --- Config ---
 EVENTS_URL = os.getenv("EVENTS_URL", "http://events:8081")
@@ -44,6 +44,10 @@ CB_COOLDOWN_S = float(os.getenv("CB_COOLDOWN_S", "30"))
 
 # Rate limiter (Lab 11) — per endpoint, sliding window
 RATE_LIMIT_RPS = int(os.getenv("RATE_LIMIT_RPS", "10"))
+
+# Bulkhead (Lab 11 Bonus) — bounded concurrency pool per downstream
+BULKHEAD_PAYMENTS_MAX = int(os.getenv("BULKHEAD_PAYMENTS_MAX", "10"))
+BULKHEAD_PAYMENTS_TIMEOUT_S = float(os.getenv("BULKHEAD_PAYMENTS_TIMEOUT_S", "0.5"))
 
 # --- Logging ---
 logging.basicConfig(
@@ -68,6 +72,13 @@ CB_STATE_TRANSITIONS = Counter(
 )
 RATE_LIMIT_REJECTIONS = Counter(
     "gateway_rate_limit_rejections_total", "Requests rejected by rate limiter", ["path"]
+)
+# Bulkhead (Lab 11 Bonus)
+BULKHEAD_IN_FLIGHT = Gauge(
+    "gateway_bulkhead_in_flight", "Current occupants of a bulkhead pool", ["target"]
+)
+BULKHEAD_REJECTIONS = Counter(
+    "gateway_bulkhead_rejections_total", "Requests rejected by a full bulkhead", ["target"]
 )
 
 client = httpx.AsyncClient(timeout=GATEWAY_TIMEOUT_MS / 1000)
@@ -101,8 +112,36 @@ async def call_with_retry(func, target: str, max_retries: int = RETRY_MAX):
     See lab 11 §11.4 for the behavior contract. The wiring (in /pay below)
     will pick up your implementation automatically.
     """
-    # TODO (Lab 11): implement exponential backoff + jitter here.
-    return await func()
+    base_delay = RETRY_BASE_DELAY_MS / 1000
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            result = await func()
+            if attempt > 0:
+                RETRY_TOTAL.labels(target=target, result="succeeded_after_retry").inc()
+            return result
+        except Exception as exc:
+            last_exc = exc
+            # Decide whether this exception is worth retrying.
+            retryable = isinstance(exc, (httpx.TimeoutException, httpx.ConnectError))
+            if isinstance(exc, httpx.HTTPStatusError):
+                status = exc.response.status_code
+                retryable = status >= 500 or status in (408, 429)
+            if not retryable:
+                # e.g. 404, 422 — won't fix itself, retrying is a bug + wasted load.
+                RETRY_TOTAL.labels(target=target, result="non_retryable").inc()
+                raise
+            if attempt == max_retries - 1:
+                # Out of attempts.
+                RETRY_TOTAL.labels(target=target, result="exhausted").inc()
+                raise
+            # Exponential backoff with full jitter to avoid a thundering herd.
+            delay = base_delay * (2 ** attempt) + random.uniform(0, base_delay)
+            RETRY_TOTAL.labels(target=target, result="retried").inc()
+            log.warning(f"retry {attempt + 1}/{max_retries} target={target} in {delay:.3f}s err={exc}")
+            await asyncio.sleep(delay)
+    # Unreachable in practice (loop always returns or raises), but keep mypy happy.
+    raise last_exc  # type: ignore[misc]
 
 
 class CircuitOpenError(Exception):
@@ -144,8 +183,28 @@ class CircuitBreaker:
         No-op default: just calls func. Lab 11 task 11.7 replaces this with
         the state machine. Raise `CircuitOpenError` when the circuit is open.
         """
-        # TODO (Lab 11): implement CLOSED/OPEN/HALF_OPEN state machine here.
-        return await func()
+        if self.state == self.OPEN:
+            if time.time() - self.opened_at >= self.cooldown:
+                # Cooldown elapsed — allow a single trial request through.
+                self._transition(self.HALF_OPEN)
+            else:
+                # Still cooling down — fast-fail without touching the dependency.
+                raise CircuitOpenError(f"circuit[{self.name}] OPEN")
+
+        try:
+            result = await func()
+        except Exception:
+            self.failures += 1
+            self.opened_at = time.time()
+            # A failure while probing (HALF_OPEN) or crossing the threshold trips OPEN.
+            if self.state == self.HALF_OPEN or self.failures >= self.threshold:
+                self._transition(self.OPEN)
+            raise
+        else:
+            # Success closes the circuit and clears the failure count.
+            self.failures = 0
+            self._transition(self.CLOSED)
+            return result
 
 
 class RateLimiter:
@@ -166,12 +225,54 @@ class RateLimiter:
 
         No-op default: always True. Lab 11 task 11.8 replaces this body.
         """
-        # TODO (Lab 11): implement sliding-window check here.
+        now = time.time()
+        q = self.hits[key]
+        cutoff = now - self.window_s
+        # Evict timestamps that fell out of the 1-second window.
+        while q and q[0] < cutoff:
+            q.popleft()
+        if len(q) >= self.rps:
+            return False
+        q.append(now)
         return True
+
+
+class BulkheadFullError(Exception):
+    """Raised by Bulkhead.call when the pool is full and acquire timed out."""
+
+
+class Bulkhead:
+    """Bounded-concurrency isolation pool for a single downstream (Lab 11 Bonus).
+
+    Each downstream gets its own asyncio.Semaphore so a slow dependency can only
+    ever occupy `max_concurrent` in-flight tasks. Once the pool is full, callers
+    wait up to `acquire_timeout_s` for a slot, then fast-fail with
+    BulkheadFullError — that keeps the gateway's event loop from filling up with
+    tasks blocked on one slow dependency (which would starve the others).
+    """
+
+    def __init__(self, name: str, max_concurrent: int, acquire_timeout_s: float):
+        self.name = name
+        self.timeout = acquire_timeout_s
+        self.sem = asyncio.Semaphore(max_concurrent)
+
+    async def call(self, func):
+        try:
+            await asyncio.wait_for(self.sem.acquire(), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            BULKHEAD_REJECTIONS.labels(target=self.name).inc()
+            raise BulkheadFullError(f"bulkhead[{self.name}] full")
+        BULKHEAD_IN_FLIGHT.labels(target=self.name).inc()
+        try:
+            return await func()
+        finally:
+            BULKHEAD_IN_FLIGHT.labels(target=self.name).dec()
+            self.sem.release()
 
 
 payments_cb = CircuitBreaker(CB_FAILURE_THRESHOLD, CB_COOLDOWN_S, name="payments")
 rate_limiter = RateLimiter(RATE_LIMIT_RPS)
+payments_bulkhead = Bulkhead("payments", BULKHEAD_PAYMENTS_MAX, BULKHEAD_PAYMENTS_TIMEOUT_S)
 
 
 # --- Middleware ---
@@ -326,9 +427,17 @@ async def pay_reservation(reservation_id: str):
         resp.raise_for_status()
         return resp
 
+    # Composition (outside → inside): bulkhead → circuit breaker → retry → call.
+    # The bulkhead gates ENTRY so all internal retries count as ONE occupant; a
+    # tripped CB's fast-fail is cheap and releases its slot immediately.
     try:
-        pay_resp = await payments_cb.call(lambda: call_with_retry(_charge, target="payments"))
+        pay_resp = await payments_bulkhead.call(
+            lambda: payments_cb.call(lambda: call_with_retry(_charge, target="payments"))
+        )
         payment_ref = pay_resp.json().get("payment_ref", "unknown")
+    except BulkheadFullError:
+        log.error("payments bulkhead full, shedding load")
+        raise HTTPException(503, "Payment service temporarily unavailable (bulkhead full)")
     except CircuitOpenError:
         log.error("circuit open, skipping payments call")
         raise HTTPException(503, "Payment service temporarily unavailable (circuit open)")

--- a/app/notifications/Dockerfile
+++ b/app/notifications/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+
+EXPOSE 8083
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8083"]

--- a/app/notifications/main.py
+++ b/app/notifications/main.py
@@ -1,0 +1,89 @@
+"""QuickTicket Notifications — Fire-and-forget notification sink.
+
+4th microservice (Lab 11). Modeled on app/payments/main.py: a mock destination
+service with tunable fault injection. The gateway calls POST /notify in a
+fire-and-forget task after a successful checkout, so this service being slow or
+failing must never affect the user-facing request.
+"""
+
+import os
+import time
+import random
+import logging
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+
+# --- Config (fault injection via env vars) ---
+NOTIFY_FAILURE_RATE = float(os.getenv("NOTIFY_FAILURE_RATE", "0.0"))
+NOTIFY_LATENCY_MS = int(os.getenv("NOTIFY_LATENCY_MS", "0"))
+
+# --- Logging ---
+logging.basicConfig(
+    format='{"time":"%(asctime)s","level":"%(levelname)s","service":"notifications","msg":"%(message)s"}',
+    level=logging.INFO,
+)
+log = logging.getLogger("notifications")
+
+# --- App ---
+app = FastAPI(title="QuickTicket Notifications", version="1.0.0")
+
+# --- Prometheus metrics ---
+REQUEST_COUNT = Counter(
+    "notifications_requests_total", "Total requests", ["method", "path", "status"]
+)
+REQUEST_DURATION = Histogram(
+    "notifications_request_duration_seconds", "Request duration", ["method", "path"]
+)
+NOTIFY_TOTAL = Counter(
+    "notifications_notify_total", "Total notify attempts", ["result"]
+)
+
+
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):
+    start = time.time()
+    response = await call_next(request)
+    duration = time.time() - start
+    path = request.url.path
+    if not path.startswith("/metrics"):
+        REQUEST_COUNT.labels(request.method, path, response.status_code).inc()
+        REQUEST_DURATION.labels(request.method, path).observe(duration)
+    return response
+
+
+@app.get("/health")
+def health():
+    return {
+        "status": "healthy",
+        "failure_rate": NOTIFY_FAILURE_RATE,
+        "latency_ms": NOTIFY_LATENCY_MS,
+    }
+
+
+@app.get("/metrics")
+def metrics():
+    from starlette.responses import Response
+
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.post("/notify")
+def notify(body: dict = None):
+    event = (body or {}).get("event", "unknown")
+    order_id = (body or {}).get("order_id", "unknown")
+
+    # Inject latency
+    if NOTIFY_LATENCY_MS > 0:
+        time.sleep(NOTIFY_LATENCY_MS / 1000)
+
+    # Inject failures
+    if random.random() < NOTIFY_FAILURE_RATE:
+        NOTIFY_TOTAL.labels("failed").inc()
+        log.warning(f"Notification failed (injected) event={event} order={order_id}")
+        raise HTTPException(500, "Notification delivery failed")
+
+    NOTIFY_TOTAL.labels("success").inc()
+    log.info(f"Notification sent event={event} order={order_id}")
+    return {"status": "sent", "event": event, "order_id": order_id}

--- a/app/notifications/requirements.txt
+++ b/app/notifications/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.136.0
+uvicorn==0.44.0
+prometheus-client==0.25.0

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -1,0 +1,74 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+    version: "v2"
+spec:
+  replicas: 5                          # need 5 for meaningful canary splits (20% = 1 pod)
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20                 # 1 of 5 pods = canary
+        - pause: {}                     # infinite pause — wait for manual promote
+        - setWeight: 60                 # 3 of 5 pods = canary
+        - pause: {duration: 30s}        # auto-proceed after 30s
+        - setWeight: 100                # full rollout
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: quickticket-gateway:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          env:
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: NOTIFICATIONS_URL
+              value: "http://notifications:8083"
+            - name: GATEWAY_TIMEOUT_MS
+              value: "5000"
+            - name: APP_VERSION
+              value: "v1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/notifications.yaml
+++ b/k8s/notifications.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications
+  labels:
+    app: notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notifications
+  template:
+    metadata:
+      labels:
+        app: notifications
+    spec:
+      containers:
+        - name: notifications
+          image: quickticket-notifications:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8083
+          env:
+            - name: NOTIFY_FAILURE_RATE
+              value: "0.0"
+            - name: NOTIFY_LATENCY_MS
+              value: "0"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8083
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8083
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notifications
+spec:
+  type: ClusterIP
+  selector:
+    app: notifications
+  ports:
+    - port: 8083
+      targetPort: 8083

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,408 @@
+# Lab 11 — Advanced Microservice Patterns
+
+Environment: local k3d cluster `quickticket`. Gateway is an Argo Rollouts `Rollout` (5 replicas)
+from Lab 7, plus events / payments / postgres / redis and the new **notifications** service. In-cluster
+Prometheus (Lab 7 Bonus) scrapes the gateway pods. Checkout traffic from `labs/lab8/mixedload.yaml`
+runs throughout. All four patterns (retry, circuit breaker, rate limiter, bulkhead) were implemented in
+`app/gateway/main.py` and exercised with real fault injection.
+
+---
+
+## Task 1 — Notifications Service + Retries
+
+### 1. `app/notifications/main.py` (key bits) + `requirements.txt`
+
+The notifications service copies the payments template: a mock destination with tunable fault injection
+(`NOTIFY_FAILURE_RATE`, `NOTIFY_LATENCY_MS`) and the three required Prometheus metrics.
+
+```python
+NOTIFY_TOTAL = Counter("notifications_notify_total", "Total notify attempts", ["result"])
+
+@app.post("/notify")
+def notify(body: dict = None):
+    event = (body or {}).get("event", "unknown")
+    order_id = (body or {}).get("order_id", "unknown")
+    if NOTIFY_LATENCY_MS > 0:
+        time.sleep(NOTIFY_LATENCY_MS / 1000)
+    if random.random() < NOTIFY_FAILURE_RATE:
+        NOTIFY_TOTAL.labels("failed").inc()
+        raise HTTPException(500, "Notification delivery failed")
+    NOTIFY_TOTAL.labels("success").inc()
+    return {"status": "sent", "event": event, "order_id": order_id}
+```
+
+Metrics emitted: `notifications_requests_total{method,path,status}`,
+`notifications_request_duration_seconds{method,path}`, `notifications_notify_total{result}`.
+
+`requirements.txt` (identical to payments — no DB, no Redis):
+
+```text
+fastapi==0.136.0
+uvicorn==0.44.0
+prometheus-client==0.25.0
+```
+
+`Dockerfile` is the payments Dockerfile with the port changed to 8083.
+
+### 2. `k8s/notifications.yaml`
+
+Deployment + Service in one file: 1 replica, `image: quickticket-notifications:v1`,
+`imagePullPolicy: Never`, container/Service port 8083, `NOTIFY_FAILURE_RATE`/`NOTIFY_LATENCY_MS` env
+defaults, `app=notifications` selector/labels. (Full file committed in the PR.)
+
+The gateway learns about it via one env var added to `k8s/gateway.yaml`:
+
+```yaml
+- name: NOTIFICATIONS_URL
+  value: "http://notifications:8083"
+```
+
+Pod comes up 1/1 Ready:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl get pod -l app=notifications
+NAME                            READY   STATUS    RESTARTS   AGE
+notifications-dccd599cc-8jgfr   1/1     Running   0          2m
+```
+
+### 3. `call_with_retry()` implementation
+
+```python
+async def call_with_retry(func, target: str, max_retries: int = RETRY_MAX):
+    base_delay = RETRY_BASE_DELAY_MS / 1000
+    last_exc = None
+    for attempt in range(max_retries):
+        try:
+            result = await func()
+            if attempt > 0:
+                RETRY_TOTAL.labels(target=target, result="succeeded_after_retry").inc()
+            return result
+        except Exception as exc:
+            last_exc = exc
+            retryable = isinstance(exc, (httpx.TimeoutException, httpx.ConnectError))
+            if isinstance(exc, httpx.HTTPStatusError):
+                status = exc.response.status_code
+                retryable = status >= 500 or status in (408, 429)
+            if not retryable:                       # 404, 422 — won't fix itself
+                RETRY_TOTAL.labels(target=target, result="non_retryable").inc()
+                raise
+            if attempt == max_retries - 1:          # out of attempts
+                RETRY_TOTAL.labels(target=target, result="exhausted").inc()
+                raise
+            delay = base_delay * (2 ** attempt) + random.uniform(0, base_delay)  # backoff + jitter
+            RETRY_TOTAL.labels(target=target, result="retried").inc()
+            await asyncio.sleep(delay)
+    raise last_exc
+```
+
+### 4. Test #1 — fire-and-forget under notify failure
+
+Injected 30% notification failures + 300ms latency, then fired 30 checkout chains:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl set env deployment/notifications NOTIFY_FAILURE_RATE=0.3 NOTIFY_LATENCY_MS=300
+deployment.apps/notifications env updated
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run checkout-burst ... -- sh -c '...30 reserve+pay...'
+result: ok=30 fail=0
+```
+
+`/pay` p99 was **not** inflated by the injected 300ms — proving the notify call is genuinely
+non-blocking:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  'http://localhost:9090/api/v1/query?query=histogram_quantile(0.99,+sum+by+(le,path)+(rate(gateway_request_duration_seconds_bucket%5B2m%5D)))'
+  path=/reserve/{id}/pay  =>  0.0219 s   (~22 ms, well under 100 ms)
+```
+
+### 5. Test #2 — retries fire under transient payment failure
+
+Injected 30% payment failures, fired 30 more checkouts:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl set env deployment/payments PAYMENT_FAILURE_RATE=0.3
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run retry-test ... -- sh -c '...30 reserve+pay...'
+result: ok=30 fail=0
+```
+
+30% first-try failure × 3 attempts ⇒ all-three-fail ≈ 0.3³ ≈ 2.7%, so ~30/30 succeed. Retries
+actually fired (both counters non-zero):
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  'http://localhost:9090/api/v1/query?query=sum+by+(target,result)+(gateway_retry_total)'
+  target=payments result=retried                => 13
+  target=payments result=succeeded_after_retry  => 11
+```
+
+### 6. Real notify failure rate (from the notifications pod `/metrics`)
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ curl -s http://notifications:8083/metrics | grep '^notifications_notify_total'
+notifications_notify_total{result="success"} 20.0
+notifications_notify_total{result="failed"} 10.0
+```
+
+10/30 ≈ **33%** real failure — matching the injected 0.3 — yet every one of the 30 checkouts still
+returned 200. The failed notifications were swallowed by the fire-and-forget task.
+
+### 7. Why should notifications be non-blocking (fire-and-forget)?
+
+Sending a confirmation e-mail/push is **not** part of the money-and-inventory transaction. The payment
+has already been charged and the order confirmed by the time we notify. If the notification call were
+`await`-ed inline, then (a) the injected 300ms latency would be added to every user's `/pay` p99, and
+(b) a notification-service outage (30% here) would turn into user-visible 5xx on checkout — the tail
+would wag the dog. By running it as `asyncio.create_task(...)` the user request returns immediately
+after the confirm step; the notification is best-effort. Test #1 proves both: p99 stayed at ~22ms and
+ok=30/30 despite 33% notify failures. This is also why the gateway `/health` deliberately does **not**
+gate `critical_ok` on notifications — a best-effort dependency being down must not mark the system down.
+
+### 8. Design prompt (11.4) — why `cb.call(retry(_charge))`, not `retry(cb.call(_charge))`?
+
+The composition is **retry INSIDE the circuit breaker**:
+`payments_cb.call(lambda: call_with_retry(_charge, "payments"))`.
+
+- The circuit breaker should see the **final** outcome of a fully-retried call as *one* success or
+  *one* failure. That keeps its failure count meaningful: "5 real failures trip the circuit," where each
+  "failure" already means "we tried 3 times and still couldn't reach payments."
+- The reverse, `retry(lambda: cb.call(_charge))`, is wrong because once the circuit is **OPEN** it
+  fast-fails with `CircuitOpenError`. The retry loop would treat that as just another error and keep
+  retrying — hammering a breaker whose whole purpose is to *stop* traffic. Worse, a `CircuitOpenError`
+  isn't even one of our retryable transient types, so the retry would (correctly) re-raise it, but the
+  intent is still inverted: you'd be retrying *around* the breaker instead of letting the breaker gate
+  the retries. The breaker must be the outermost guard so an OPEN circuit short-circuits the entire
+  retry budget in one fast-fail.
+
+> Note (from Pitfalls): because retry is inside the CB, one "failure" the CB counts is up to 3 downstream
+> calls. Under the CB test below, 5 external failures per pod = up to 15 real payment calls per pod. That
+> amplification is expected; it's the cost of retry-then-trip.
+
+---
+
+## Task 2 — Circuit Breaker + Rate Limiter
+
+### `CircuitBreaker.call` implementation
+
+```python
+async def call(self, func):
+    if self.state == self.OPEN:
+        if time.time() - self.opened_at >= self.cooldown:
+            self._transition(self.HALF_OPEN)          # cooldown elapsed → probe
+        else:
+            raise CircuitOpenError(f"circuit[{self.name}] OPEN")   # fast-fail
+    try:
+        result = await func()
+    except Exception:
+        self.failures += 1
+        self.opened_at = time.time()
+        if self.state == self.HALF_OPEN or self.failures >= self.threshold:
+            self._transition(self.OPEN)
+        raise
+    else:
+        self.failures = 0
+        self._transition(self.CLOSED)
+        return result
+```
+
+### `RateLimiter.allow` implementation
+
+```python
+def allow(self, key: str) -> bool:
+    now = time.time()
+    q = self.hits[key]
+    cutoff = now - self.window_s
+    while q and q[0] < cutoff:      # evict timestamps older than 1s
+        q.popleft()
+    if len(q) >= self.rps:
+        return False
+    q.append(now)
+    return True
+```
+
+### Circuit OPENs under 100% payment failure
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl set env deployment/payments PAYMENT_FAILURE_RATE=1.0
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run cb-probe ... 80 attempts ...
+500s=25 503s=43
+```
+
+- **500** = retry-exhausted (all 3 attempts failed, circuit still counting up).
+- **503** = fast-fail because the circuit is OPEN — 43 of 68 attempts short-circuited without touching
+  payments.
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  'http://localhost:9090/api/v1/query?query=sum+by+(to)+(gateway_circuit_breaker_transitions_total)'
+  to=OPEN => 5
+```
+
+One OPEN transition per gateway pod — with 5 replicas each has its own per-process breaker, exactly as
+the lab's gotcha predicts (that's why we need ≥40–80 requests before every pod's circuit trips).
+
+### Circuit CLOSES after recovery
+
+Restored payments to 0% failure, waited past the 30s cooldown, probed 15 checkouts:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl set env deployment/payments PAYMENT_FAILURE_RATE=0.0
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run cb-probe2 ...  # sleep 35 then 15 pays
+[1] 200
+[2] 200
+...
+[15] 200
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  'http://localhost:9090/api/v1/query?query=sum+by+(to)+(gateway_circuit_breaker_transitions_total)'
+  to=OPEN      => 5
+  to=HALF_OPEN => 5
+  to=CLOSED    => 5
+```
+
+Full state cycle proven across all 5 pods: OPEN → (cooldown) → HALF_OPEN → (trial succeeds) → CLOSED.
+
+### Rate limiter — burst returns 429, sustained load doesn't
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run rl-burst ... 100 rapid /events ...
+200=44 429=56
+```
+
+Cluster ceiling = per-pod `RATE_LIMIT_RPS` (10) × 5 replicas ≈ 50 rps; a 100-request burst gets roughly
+half limited. The 429 carries the `Retry-After` header clients use to back off:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run rl-hdr2 ... curl -D - ... | grep -i 429
+HTTP/1.1 429 Too Many Requests retry-after: 1
+```
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  'http://localhost:9090/api/v1/query?query=sum+by+(path)+(gateway_rate_limit_rejections_total)'
+  path=/events              => 59
+  path=/events/{id}/reserve => 10
+  path=/reserve/{id}/pay    => 3
+```
+
+Sustained load **below** the limit (5 rps, `sleep 0.2`) sees zero rejections:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run rl-slow ... 30 reqs @ 5rps ...
+sustained(5rps): 200=30 429=0
+```
+
+---
+
+## Bonus Task — Bulkhead Isolation
+
+### `Bulkhead.call` + wiring
+
+```python
+class Bulkhead:
+    def __init__(self, name, max_concurrent, acquire_timeout_s):
+        self.name = name
+        self.timeout = acquire_timeout_s
+        self.sem = asyncio.Semaphore(max_concurrent)
+
+    async def call(self, func):
+        try:
+            await asyncio.wait_for(self.sem.acquire(), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            BULKHEAD_REJECTIONS.labels(target=self.name).inc()
+            raise BulkheadFullError(f"bulkhead[{self.name}] full")
+        BULKHEAD_IN_FLIGHT.labels(target=self.name).inc()
+        try:
+            return await func()
+        finally:
+            BULKHEAD_IN_FLIGHT.labels(target=self.name).dec()
+            self.sem.release()
+```
+
+Wired in `pay_reservation` **outside** the circuit breaker:
+
+```python
+pay_resp = await payments_bulkhead.call(
+    lambda: payments_cb.call(lambda: call_with_retry(_charge, target="payments"))
+)
+...
+except BulkheadFullError:
+    raise HTTPException(503, "Payment service temporarily unavailable (bulkhead full)")
+```
+
+Composition outside→inside: **bulkhead → circuit breaker → retry → call.**
+
+### Test setup
+
+To make a *per-process* bulkhead observable I scaled the gateway to **1 replica** (otherwise 30 concurrent
+`/pay` spread over 5 pods = 6 each, never reaching MAX=10 — the same per-process limitation as the circuit
+breaker in Task 2) and set `RATE_LIMIT_RPS=1000` so the burst's reserve/pay calls weren't throttled before
+reaching the bulkhead. Injected `PAYMENT_LATENCY_MS=3000`.
+
+### With bulkhead (MAX=10) — cap binds, events stay fast
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run bulkhead-probe ... 30 concurrent /pay + sample /events ...
+EVENTS: ok=30 slow=0
+pay 200: 10      # grabbed the 10 slots, completed after ~3s
+pay 503: 12      # bulkhead full → fast-fail within the 500ms acquire timeout
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  '.../query?query=sum+by+(target)+(gateway_bulkhead_rejections_total)'
+  target=payments => 12
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  '.../query?query=max_over_time(gateway_bulkhead_in_flight{target="payments"}[5m])'
+  in_flight max = 10        # == BULKHEAD_PAYMENTS_MAX — the cap actually binds
+```
+
+### Without effective bulkhead (MAX=1000) — contrast
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl patch rollout gateway ... BULKHEAD_PAYMENTS_MAX=1000 ...
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl run bulkhead-probe2 ... same probe ...
+EVENTS: ok=30 slow=0
+pay 200: 21      # all reservations that succeeded proceeded; no 503s
+```
+
+### Honest finding
+
+`/events` stayed **fast in both cases**. On this gateway that is the *correct* result: FastAPI + uvicorn
++ `httpx.AsyncClient` is fully asynchronous, so 30 concurrently-`await`-ed 3-second payment calls do **not**
+block the event loop — asyncio just schedules them all and the loop stays free to serve `/events`. The
+lab's "without bulkhead → `/events` slow=30" prediction assumes a **blocking / thread-pool** stack (sync
+Flask/Django, or a saturated connection pool), where each slow call ties up a worker thread. It does not
+reproduce on a non-blocking stack, and I did not fabricate a result to force it.
+
+What the bulkhead *did* demonstrably buy us here is **load-shedding**: with the cap, 12 of the excess
+requests fast-failed with 503 in under 500ms instead of hanging for 3 seconds, and in-flight was held at
+exactly 10. That's the real, measured value of the bulkhead on an async gateway — bounded resource use and
+fast rejection under overload, rather than event-loop protection that async already provides for free.
+
+### Bonus design answers
+
+**Why must the bulkhead wrap the circuit breaker, not the other way around?**
+The bulkhead gates *entry* to the whole payments call. Because retries live *inside* the bulkhead slot, all
+3 retry attempts for one logical `/pay` count as **one** occupant — so `MAX=10` really means "10 in-flight
+payment operations," not "10 attempts" (which 3 retries would blow through instantly). If the bulkhead were
+*inside* the CB, a CB fast-fail (`CircuitOpenError`) — which is meant to be instant and free — would still
+have consumed a bulkhead slot on the way in. Anything that fast-fails must not hold a slot. Outermost
+bulkhead = a slot is held only for the duration of a real, in-flight downstream call.
+
+**Bulkhead vs rate limiter — what does each protect against?**
+The **rate limiter** caps the *incoming request rate per endpoint* — it protects the system (and the
+downstream) from too many requests per second, a cluster-wide throughput ceiling (`RPS × replicas`). The
+**bulkhead** caps *concurrent in-flight calls to one specific dependency* — it protects the *other*
+dependencies from a single slow one by isolating its resource pool. Rate limiter = "too many requests,
+slow down" (429). Bulkhead = "this one dependency is saturated, shed load for it so the rest keep working"
+(503). One bounds arrival rate; the other bounds concurrency per downstream.
+
+---
+
+## PR checklist
+
+```text
+- [x] Task 1 done — notifications service, k8s manifest, fire-and-forget wiring, retry with backoff (Tests #1 + #2)
+- [x] Task 2 done — circuit breaker + rate limiter, tested under failure
+- [x] Bonus Task done — bulkhead isolation, concurrent /pay vs /events test, cap proven to bind
+```


### PR DESCRIPTION
## Lab 11 — Advanced Microservice Patterns

Notifications service (4th microservice) + resilience patterns implemented in `app/gateway/main.py`,
all exercised with real fault injection on a local k3d cluster (5-replica gateway Rollout + in-cluster
Prometheus + mixedload traffic).

### What's here
- `app/notifications/` — new microservice (fire-and-forget destination, tunable fault injection, 3 metrics).
- `app/gateway/main.py` — real `call_with_retry` (backoff + jitter), `CircuitBreaker.call` state machine,
  `RateLimiter.allow` sliding window, and the bonus `Bulkhead` (per-target semaphore) wired outside the CB.
- `k8s/notifications.yaml`, `k8s/gateway.yaml` (adds `NOTIFICATIONS_URL`), `app/docker-compose.yaml`.
- `submissions/lab11.md` — full write-up with real Prometheus/curl evidence for every test.

### Evidence highlights
- **Test #1 (fire-and-forget):** 30/30 checkouts OK under `NOTIFY_FAILURE_RATE=0.3` + 300ms; `/pay` p99 ≈ 22ms.
- **Test #2 (retries):** 30/30 OK under `PAYMENT_FAILURE_RATE=0.3`; `gateway_retry_total{retried}=13`, `{succeeded_after_retry}=11`.
- **Circuit breaker:** OPEN under 100% failure (503 fast-fail), full OPEN→HALF_OPEN→CLOSED cycle (5 pods).
- **Rate limiter:** 100-burst → 44×200 / 56×429 with `Retry-After: 1`; sustained 5rps → 0 rejections.
- **Bulkhead:** cap binds — `in_flight` max = 10, 12 fast-fail 503s; honest note on async event-loop behavior.

### PR checklist
- [x] Task 1 — notifications service, k8s manifest, fire-and-forget wiring, retry with backoff (Tests #1 + #2)
- [x] Task 2 — circuit breaker + rate limiter, tested under failure
- [x] Bonus Task — bulkhead isolation, concurrent /pay vs /events test, cap proven to bind
