### PR TITLE
feat(lab12): PDBs, graceful shutdown, and zero-downtime migration

### DIFF
--- a/app/events/main.py
+++ b/app/events/main.py
@@ -140,11 +140,16 @@ def list_events():
     conn = db_pool.getconn()
     try:
         cur = conn.cursor()
+        # Deploy B (Lab 12 expand-and-contract): scheduled_at is backfilled and
+        # NOT NULL, so read it directly. Still aliased as event_date to keep the
+        # /events response shape byte-for-byte backward-compatible.
         cur.execute("""
-            SELECT e.id, e.name, e.venue, e.event_date, e.total_tickets, e.price_cents,
+            SELECT e.id, e.name, e.venue,
+                   e.scheduled_at AS event_date,
+                   e.total_tickets, e.price_cents,
                    COALESCE(SUM(o.quantity), 0) as confirmed
             FROM events e LEFT JOIN orders o ON e.id = o.event_id
-            GROUP BY e.id ORDER BY e.event_date
+            GROUP BY e.id ORDER BY e.scheduled_at
         """)
         rows = cur.fetchall()
         cur.close()
@@ -165,8 +170,11 @@ def get_event(event_id: int):
     conn = db_pool.getconn()
     try:
         cur = conn.cursor()
+        # Deploy B: read scheduled_at directly for the single-event read.
         cur.execute("""
-            SELECT e.id, e.name, e.venue, e.event_date, e.total_tickets, e.price_cents,
+            SELECT e.id, e.name, e.venue,
+                   e.scheduled_at AS event_date,
+                   e.total_tickets, e.price_cents,
                    COALESCE(SUM(o.quantity), 0) as confirmed
             FROM events e LEFT JOIN orders o ON e.id = o.event_id
             WHERE e.id = %s GROUP BY e.id

--- a/app/seed.sql
+++ b/app/seed.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS events (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     venue TEXT NOT NULL,
-    event_date TIMESTAMPTZ NOT NULL,
+    scheduled_at TIMESTAMPTZ NOT NULL,
     total_tickets INT NOT NULL,
     price_cents INT NOT NULL
 );
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS orders (
 );
 
 -- Seed events
-INSERT INTO events (name, venue, event_date, total_tickets, price_cents) VALUES
+INSERT INTO events (name, venue, scheduled_at, total_tickets, price_cents) VALUES
     ('Go Conference 2026', 'Main Hall A', '2026-09-15 09:00:00+00', 100, 5000),
     ('SRE Meetup', 'Room 204', '2026-10-01 18:00:00+00', 30, 0),
     ('Cloud Native Summit', 'Expo Center', '2026-11-20 10:00:00+00', 500, 15000),

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+  labels:
+    app: events
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: events
+  template:
+    metadata:
+      labels:
+        app: events
+    spec:
+      # Graceful shutdown so the two Lab 12 code deploys (expand-and-contract)
+      # drop zero requests: preStop lets kube-proxy remove this pod's endpoint
+      # before uvicorn gets SIGTERM, avoiding the connection-refused window.
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: events
+          image: quickticket-events:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8081
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          env:
+            - name: DB_HOST
+              value: "postgres"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "quickticket"
+            - name: DB_USER
+              value: "quickticket"
+            - name: DB_PASS
+              value: "quickticket"
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: events
+spec:
+  type: ClusterIP
+  selector:
+    app: events
+  ports:
+    - port: 8081
+      targetPort: 8081

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -1,0 +1,92 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+    version: "v2"
+spec:
+  replicas: 5                          # need 5 for meaningful canary splits (20% = 1 pod)
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20                 # 1 of 5 pods = canary
+        - pause: {}                     # infinite pause — wait for manual promote
+        - setWeight: 60                 # 3 of 5 pods = canary
+        - pause: {duration: 30s}        # auto-proceed after 30s
+        - setWeight: 100                # full rollout
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+    spec:
+      # Cover preStop (10s) + in-flight request drain (up to 30s) before SIGKILL.
+      terminationGracePeriodSeconds: 40
+      # Spread gateway pods across nodes so one node loss can't take them all.
+      # ScheduleAnyway (not DoNotSchedule) so single-node k3d still schedules.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: gateway
+      containers:
+        - name: gateway
+          image: quickticket-gateway:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          lifecycle:
+            # Sleep BEFORE SIGTERM reaches uvicorn: gives kube-proxy / endpoints
+            # controllers time to propagate this pod's NotReady state to every
+            # node so new traffic stops routing here before the app shuts down.
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          env:
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: NOTIFICATIONS_URL
+              value: "http://notifications:8083"
+            - name: GATEWAY_TIMEOUT_MS
+              value: "5000"
+            - name: APP_VERSION
+              value: "v1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 2
+            failureThreshold: 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/notifications.yaml
+++ b/k8s/notifications.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications
+  labels:
+    app: notifications
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: notifications
+  template:
+    metadata:
+      labels:
+        app: notifications
+    spec:
+      containers:
+        - name: notifications
+          image: quickticket-notifications:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8083
+          env:
+            - name: NOTIFY_FAILURE_RATE
+              value: "0.0"
+            - name: NOTIFY_LATENCY_MS
+              value: "0"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8083
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8083
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notifications
+spec:
+  type: ClusterIP
+  selector:
+    app: notifications
+  ports:
+    - port: 8083
+      targetPort: 8083

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  labels:
+    app: payments
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      containers:
+        - name: payments
+          image: quickticket-payments:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8082
+          env:
+            - name: PAYMENT_FAILURE_RATE
+              value: "0.0"
+            - name: PAYMENT_LATENCY_MS
+              value: "0"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+spec:
+  type: ClusterIP
+  selector:
+    app: payments
+  ports:
+    - port: 8082
+      targetPort: 8082

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,52 @@
+# PodDisruptionBudgets for QuickTicket (Lab 12).
+#
+# A PDB caps how many pods of a workload may be *voluntarily* disrupted at once
+# (node drain, cluster upgrade, `kubectl drain`) — it does NOT protect against
+# involuntary disruption (a node crash). It gates the eviction API so a drain
+# can never take a service below its floor.
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway-pdb
+spec:
+  # 5 replicas, minAvailable 2 → tolerate 3 simultaneous evictions during a drain.
+  # Not 4: that would leave only 1 evictable at a time and a node drain could
+  # block forever. 2 keeps ~half of normal RPS while the rest reschedule.
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: gateway
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: events-pdb
+spec:
+  # 2 replicas, must always keep 1 serving.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: events
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payments-pdb
+spec:
+  # 2 replicas, must always keep 1 serving.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: payments
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notifications-pdb
+spec:
+  # Best-effort (fire-and-forget in Lab 11) → a softer bar: at most 1 down.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: notifications

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,78 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/304972d3e8bf_index_events_event_date_concurrently.py
+++ b/migrations/versions/304972d3e8bf_index_events_event_date_concurrently.py
@@ -1,0 +1,50 @@
+"""index events.event_date concurrently
+
+Revision ID: 304972d3e8bf
+Revises: b8891ec9e21a
+Create Date: 2026-07-14 14:16:53.027970
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '304972d3e8bf'
+down_revision: Union[str, Sequence[str], None] = 'b8891ec9e21a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create the index CONCURRENTLY, outside Alembic's default transaction.
+
+    CREATE INDEX CONCURRENTLY cannot run inside a transaction block, so we drop
+    out of Alembic's transactional DDL with autocommit_block(). CONCURRENTLY
+    takes a milder SHARE UPDATE EXCLUSIVE lock that does NOT block reads/writes,
+    so this is safe under live traffic. if_not_exists keeps it re-runnable if a
+    previous attempt was interrupted (a CONCURRENTLY build can leave an INVALID
+    index behind).
+    """
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "idx_events_event_date",
+            "events",
+            ["event_date"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    """Drop the index CONCURRENTLY (mirror of upgrade)."""
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_events_event_date",
+            table_name="events",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/migrations/versions/8da3f9006d53_baseline_pre_existing_schema.py
+++ b/migrations/versions/8da3f9006d53_baseline_pre_existing_schema.py
@@ -1,0 +1,28 @@
+"""baseline - pre-existing schema
+
+Revision ID: 8da3f9006d53
+Revises: 
+Create Date: 2026-07-09 16:46:09.433651
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8da3f9006d53'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/migrations/versions/a454c61be623_drop_events_event_date.py
+++ b/migrations/versions/a454c61be623_drop_events_event_date.py
@@ -1,0 +1,39 @@
+"""drop events.event_date
+
+Revision ID: a454c61be623
+Revises: d95c13f14ad7
+Create Date: 2026-07-14 14:31:06.117364
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a454c61be623'
+down_revision: Union[str, Sequence[str], None] = 'd95c13f14ad7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Contract: drop the old column now that Deploy B neither reads nor writes it.
+
+    Safe ONLY here: Deploy B is fully rolled out, so no live pod references
+    event_date. (Dropping the column also drops idx_events_event_date from 12.7,
+    since an index cannot outlive its column.) Running this before Deploy B was
+    complete would 500 every /events request on any surviving Deploy-A pod, whose
+    COALESCE still names event_date.
+    """
+    op.drop_column("events", "event_date")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("event_date", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.execute("UPDATE events SET event_date = scheduled_at")
+    op.alter_column("events", "event_date", nullable=False)

--- a/migrations/versions/b8891ec9e21a_add_email_column_to_events.py
+++ b/migrations/versions/b8891ec9e21a_add_email_column_to_events.py
@@ -1,0 +1,28 @@
+"""add email column to events
+
+Revision ID: b8891ec9e21a
+Revises: 8da3f9006d53
+Create Date: 2026-07-09 16:46:17.485929
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8891ec9e21a'
+down_revision: Union[str, Sequence[str], None] = '8da3f9006d53'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Adding a nullable column is a metadata-only change in PostgreSQL 11+ —
+    # no table rewrite, no blocking lock on SELECT/INSERT. Safe under load.
+    op.add_column('events', sa.Column('email', sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('events', 'email')

--- a/migrations/versions/d95c13f14ad7_backfill_events_scheduled_at.py
+++ b/migrations/versions/d95c13f14ad7_backfill_events_scheduled_at.py
@@ -1,0 +1,36 @@
+"""backfill events.scheduled_at
+
+Revision ID: d95c13f14ad7
+Revises: ed097f0d82b9
+Create Date: 2026-07-14 14:29:07.600551
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd95c13f14ad7'
+down_revision: Union[str, Sequence[str], None] = 'ed097f0d82b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Backfill scheduled_at from event_date, then enforce NOT NULL.
+
+    Idempotent (WHERE scheduled_at IS NULL) so a re-run is a no-op. Safe under
+    live traffic because Deploy A reads via COALESCE and tolerates both NULL and
+    non-NULL scheduled_at. On a 10M-row table this UPDATE would be batched
+    (WHERE id BETWEEN x AND y, chunks of ~10k, sleeping between) to avoid a long
+    transaction lock; QuickTicket's 5-row seed finishes instantly.
+    """
+    op.execute("UPDATE events SET scheduled_at = event_date WHERE scheduled_at IS NULL")
+    op.alter_column("events", "scheduled_at", nullable=False)
+
+
+def downgrade() -> None:
+    # No need to UPDATE back — event_date still holds the data.
+    op.alter_column("events", "scheduled_at", nullable=True)

--- a/migrations/versions/ed097f0d82b9_add_events_scheduled_at_column.py
+++ b/migrations/versions/ed097f0d82b9_add_events_scheduled_at_column.py
@@ -1,0 +1,35 @@
+"""add events.scheduled_at column
+
+Revision ID: ed097f0d82b9
+Revises: 304972d3e8bf
+Create Date: 2026-07-14 14:22:30.076768
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ed097f0d82b9'
+down_revision: Union[str, Sequence[str], None] = '304972d3e8bf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Expand: add the new column, nullable so it is instant on a populated table.
+
+    A NOT NULL column with no default would fail to add to a table with existing
+    rows; even with a default, on a large table the rewrite takes an ACCESS
+    EXCLUSIVE lock. nullable=True is a metadata-only change — safe under traffic.
+    """
+    op.add_column(
+        "events",
+        sa.Column("scheduled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "scheduled_at")

--- a/submissions/lab12.md
+++ b/submissions/lab12.md
@@ -1,0 +1,357 @@
+# Lab 12 — Advanced Kubernetes Resilience
+
+Environment: local k3d cluster `quickticket` (single node). Gateway is a 5-replica Argo Rollouts
+`Rollout`; events / payments / notifications scaled to 2 replicas; Postgres + Redis + in-cluster
+Prometheus. `labs/lab8/mixedload.yaml` drives checkout traffic throughout. Alembic runs from the host
+against Postgres via `kubectl port-forward svc/postgres 5432:5432`.
+
+---
+
+## Task 1 — Multi-Replica Failover + PDBs
+
+### 1. Services at target replica counts
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl get deploy,rollout
+NAME                            READY   UP-TO-DATE   AVAILABLE
+deployment.apps/events          2/2     2            2
+deployment.apps/notifications   2/2     2            2
+deployment.apps/payments        2/2     2            2
+
+NAME                          DESIRED   CURRENT   READY   AVAILABLE
+rollout.argoproj.io/gateway   5         5         5       5
+```
+
+### 2. Zero 5xx during a coordinated pod-kill under load
+
+```console
+# before
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  '.../query?query=sum(increase(gateway_requests_total{status=~"5.."}[3m]))'
+  5xx = 0
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl delete pod $(kubectl get pod -l app=gateway -o jsonpath='{.items[0].metadata.name}') --wait=false
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl delete pod $(kubectl get pod -l app=events  -o jsonpath='{.items[0].metadata.name}') --wait=false
+# both replacement pods Ready within ~5s; Service endpoints reroute to survivors during the gap
+
+# after (1m window covers the kill)
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -n monitoring deployment/prometheus -- wget -qO- \
+  '.../query?query=sum(increase(gateway_requests_total{status=~"5.."}[1m]))'
+  5xx = 0
+```
+
+The surviving replica of each service absorbed traffic while the killed pod was replaced — zero 5xx.
+
+### 3. `kubectl get pdb`
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl get pdb
+NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS
+events-pdb          1               N/A               1
+gateway-pdb         2               N/A               3
+notifications-pdb   N/A             1                 1
+payments-pdb        1               N/A               1
+```
+
+Matches the design: gateway tolerates 3 simultaneous evictions (5 − 2), events/payments keep ≥1,
+notifications is best-effort (`maxUnavailable: 1`).
+
+### 4. Topology spread — in the live spec, placement on single-node k3d
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl get rollout gateway -o jsonpath='{.spec.template.spec.topologySpreadConstraints}' | python3 -m json.tool
+[
+    {
+        "labelSelector": {"matchLabels": {"app": "gateway"}},
+        "maxSkew": 1,
+        "topologyKey": "kubernetes.io/hostname",
+        "whenUnsatisfiable": "ScheduleAnyway"
+    }
+]
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl get pod -l app=gateway -o wide
+gateway-...-5z4vh   k3d-quickticket-server-0
+gateway-...-9lhdw   k3d-quickticket-server-0
+gateway-...-dtgdx   k3d-quickticket-server-0
+gateway-...-g477b   k3d-quickticket-server-0
+gateway-...-sdcwb   k3d-quickticket-server-0
+```
+
+All 5 pods land on the single node — expected on single-node k3d. The YAML is correct and live in the
+spec; `ScheduleAnyway` (not `DoNotSchedule`) is what keeps them schedulable here.
+
+### 5. PDB actually blocks an eviction (HTTP 429)
+
+Tightened `events-pdb` to `minAvailable: 2` (zero tolerance with 2 replicas), then fired one eviction
+through the API via `kubectl proxy`:
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl patch pdb events-pdb --type=merge -p '{"spec":{"minAvailable":2}}'
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl get pdb events-pdb    # ALLOWED DISRUPTIONS = 0
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ curl -s -X POST .../pods/$POD/eviction -d '{"apiVersion":"policy/v1","kind":"Eviction",...}'
+{
+  "status": "Failure",
+  "message": "Cannot evict pod as it would violate the pod's disruption budget.",
+  "reason": "TooManyRequests",
+  "details": {"causes": [{"reason": "DisruptionBudget",
+      "message": "The disruption budget events-pdb needs 2 healthy pods and has 2 currently"}]},
+  "code": 429
+}
+```
+
+`HTTP 429`, `reason: DisruptionBudget` — the PDB rejected the voluntary disruption. Restored to
+`minAvailable: 1` afterward.
+
+### 6. PDB math
+
+With **3 replicas** and `minAvailable: 1`, the API allows up to **2** pods evicted simultaneously
+(3 − 1). My `gateway-pdb` uses `minAvailable: 2` with **5 replicas** → tolerates **3** evictions at once,
+which is enough to let a node drain make progress (reschedule ~3 pods) while still keeping ~40% of gateway
+capacity serving. Setting it to `4` would only ever allow 1 eviction at a time and a multi-pod node drain
+could stall.
+
+### 7. Topology spread in a real 3-node cluster
+
+`maxSkew: 1` bounds the difference between the most- and least-loaded node.
+- **5 pods / 3 nodes:** placement **2 / 2 / 1** (skew 1). Never 4/1/0 or 5/0/0.
+- **7 pods / 3 nodes:** placement **3 / 2 / 2** (skew 1). Never 4/2/1 (skew 2).
+
+---
+
+## Task 2 — Graceful Shutdown + Zero-Downtime Migration
+
+### `preStop` + `readinessProbe` (gateway Rollout)
+
+```yaml
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: gateway
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 2
+            failureThreshold: 1
+```
+
+The `preStop` sleep holds the container alive after the pod is marked NotReady, giving kube-proxy /
+endpoints controllers time to drop this pod from every node's routing **before** uvicorn gets SIGTERM —
+so no request is sent to a shutting-down pod. `terminationGracePeriodSeconds: 40` covers the 10s preStop
+plus in-flight drain.
+
+### Zero 5xx during a rolling restart under load
+
+```console
+# before
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ ... sum(increase(gateway_requests_total{status=~"5.."}[1m]))
+  5xx = 0
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl argo rollouts restart gateway
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl argo rollouts status gateway --timeout=240s
+Healthy
+
+# after
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ ... sum(increase(gateway_requests_total{status=~"5.."}[3m]))
+  5xx = 0
+```
+
+(`kubectl rollout restart deployment/gateway` would fail — gateway is a `rollout.argoproj.io`, not a
+`deployment.apps`. Use `kubectl argo rollouts restart gateway`.)
+
+### `CREATE INDEX CONCURRENTLY` migration
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "idx_events_event_date", "events", ["event_date"],
+            unique=False, postgresql_concurrently=True, if_not_exists=True,
+        )
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index("idx_events_event_date", table_name="events",
+                      postgresql_concurrently=True, if_exists=True)
+```
+
+The `autocommit_block()` is the key detail — Alembic wraps migrations in a transaction by default, but
+`CREATE INDEX CONCURRENTLY cannot run inside a transaction block`.
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ time alembic upgrade head
+INFO  [alembic.runtime.migration] Running upgrade b8891ec9e21a -> 304972d3e8bf, index events.event_date concurrently
+real    0m0.296s
+
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ kubectl exec -i $(kubectl get pod -l app=postgres -o name) -- psql -U quickticket -d quickticket -c '\d events' | grep idx_events
+    "idx_events_event_date" btree (event_date)
+```
+
+5xx before = after = 0 (identical) — no impact under live traffic.
+
+### Why `CREATE INDEX CONCURRENTLY` matters
+
+A plain `CREATE INDEX` takes an **ACCESS EXCLUSIVE** lock on the table for the whole build — every read
+and write blocks until it finishes. On a 10M-row table that can be **minutes** of full-table stall = a
+user-visible outage. `CONCURRENTLY` builds the index with a milder **SHARE UPDATE EXCLUSIVE** lock that
+does not block reads or writes (it does two table scans and takes longer, but online). The trade-off:
+it can't run inside a transaction, and an interrupted build can leave an `INVALID` index behind — hence
+`if_not_exists=True` to keep it re-runnable. At QuickTicket's 5-row scale the difference is invisible;
+you learn the right syntax now so you don't learn it during an outage.
+
+### 12.8 — Expand-and-contract rename sketch (`event_date` → `scheduled_at`)
+
+**3 migrations + 2 code deploys, interleaved. Invariant: at every step both the old and the new code
+must work.**
+
+1. **Migration 1 (expand):** `ALTER TABLE events ADD COLUMN scheduled_at TIMESTAMPTZ NULL;` — nullable so
+   it's an instant metadata-only change. Old code ignores it; new column is all NULL.
+2. **Code deploy A (dual-write / fallback-read):** read `COALESCE(scheduled_at, event_date)`; write to
+   **both** columns. Tolerates rows where `scheduled_at` is still NULL.
+3. **Migration 2 (backfill):** `UPDATE events SET scheduled_at = event_date WHERE scheduled_at IS NULL;`
+   then `ALTER COLUMN scheduled_at SET NOT NULL`. Idempotent; safe because Deploy A already tolerates both
+   NULL and non-NULL via COALESCE. (At scale, batch the UPDATE.)
+4. **Code deploy B (switch):** read and write **only** `scheduled_at`. No code references `event_date`.
+5. **Migration 3 (contract):** `ALTER TABLE events DROP COLUMN event_date;` — safe only now, because no
+   running code touches `event_date` anymore.
+
+### Why migration 3 must come after deploy B is fully rolled out
+
+Migration 3 removes `event_date`. If it ran while any Deploy-A pod were still live, that pod's
+`COALESCE(scheduled_at, event_date)` (and its dual-write) would reference a column that no longer exists
+→ every `/events` request on that pod 500s. The column may only be dropped once **no** running code reads
+or writes it — i.e. after `kubectl rollout status` confirms Deploy B is 100% rolled out. Drop-before-switch
+is the classic way to turn a "zero-downtime" rename into an outage.
+
+> **12.9 HPA:** skipped — it's the explicitly-optional, non-graded observation, and `k8s/gateway-hpa.yaml`
+> is not in the lab's submit file list, so it's left out to keep the PR to exactly the requested files.
+
+---
+
+## Bonus Task — Execute the Expand-and-Contract Rename (live)
+
+Ran the full sequence on the live cluster under `mixedload`. **First hardened the `events` Deployment
+with a `preStop` hook + `terminationGracePeriodSeconds: 40`** — without it, an events rolling restart
+briefly routes traffic to a terminating pod (I measured 2×502 on an early attempt), because unlike the
+gateway the events Deployment had no graceful-drain window. This is the Task-2 graceful-shutdown lesson
+applied to `events`, and it's what makes the two code deploys genuinely zero-downtime.
+
+### The three migration `upgrade()` bodies
+
+```python
+# M1 — add_events_scheduled_at
+op.add_column("events", sa.Column("scheduled_at", sa.TIMESTAMP(timezone=True), nullable=True))
+
+# M2 — backfill_events_scheduled_at
+op.execute("UPDATE events SET scheduled_at = event_date WHERE scheduled_at IS NULL")
+op.alter_column("events", "scheduled_at", nullable=False)
+
+# M3 — drop_events_event_date
+op.drop_column("events", "event_date")
+```
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ alembic history
+a454c61be623 (head), drop events.event_date
+d95c13f14ad7,      backfill events.scheduled_at
+ed097f0d82b9,      add events.scheduled_at column
+304972d3e8bf,      index events.event_date concurrently
+b8891ec9e21a,      add email column to events
+8da3f9006d53,      baseline - pre-existing schema
+```
+
+### `app/events/main.py` diff — Deploy A → Deploy B (the read path)
+
+```diff
+-        # Deploy A: prefer scheduled_at, fall back to event_date (COALESCE).
+-                   COALESCE(e.scheduled_at, e.event_date) AS event_date,
+-            GROUP BY e.id ORDER BY COALESCE(e.scheduled_at, e.event_date)
++        # Deploy B: scheduled_at is backfilled + NOT NULL, read it directly.
++                   e.scheduled_at AS event_date,
++            GROUP BY e.id ORDER BY e.scheduled_at
+```
+
+I kept the `AS event_date` alias through Deploy B so the `/events` response shape stays byte-for-byte
+identical — the gateway and any client never see the rename. QuickTicket has no runtime INSERT of event
+rows (the only writer is `app/seed.sql` at boot), so there was no dual-**write** path to change; the seed
+was updated to `scheduled_at` in Deploy B. Noted here per the lab.
+
+### `\d events` before M1 and after M3
+
+```console
+# BEFORE (has event_date, NOT NULL, plus idx_events_event_date)
+ event_date    | timestamp with time zone | not null
+    "idx_events_event_date" btree (event_date)
+
+# AFTER M3 (event_date gone; scheduled_at is NOT NULL; index dropped with its column)
+ scheduled_at  | timestamp with time zone | not null
+```
+
+### Zero 5xx across all 5 transitions
+
+```console
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ cat /tmp/5xx.baseline   # snapshot before M1
+2
+# ... M1 → Deploy A → M2 → Deploy B → M3, each checked: delta 0 ...
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ cat /tmp/5xx.final
+2
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$ diff /tmp/5xx.baseline /tmp/5xx.final
+MacBook-Pro-pon4ik:SRE-Intro rolanmulukin$    # (no output = identical = zero 5xx delta)
+```
+
+(The baseline of `2` is residual from an earlier non-graceful events restart, baked into the snapshot;
+the point is the **delta** across the five transitions is **0**. Final checkout `reserve`→`pay` = 200.)
+
+### Bonus design answers
+
+**Which single step, if reordered earlier, would have caused 5xx?**
+**Migration 3 (drop `event_date`).** Every other step only *adds* capability: M1 adds a nullable column
+(no reader depends on it), Deploy A adds a fallback read, M2 backfills (Deploy A already tolerates both
+states), Deploy B narrows to the new column (M2 guaranteed it's populated + NOT NULL). Only M3 *removes*
+something. Run before Deploy B is fully out, any surviving Deploy-A pod's `COALESCE(..., event_date)`
+references a dropped column and 500s on every `/events` call.
+
+**Batching the backfill on a 10M-row table (pseudocode):**
+```text
+last_id = 0
+loop:
+    rows = UPDATE events SET scheduled_at = event_date
+           WHERE scheduled_at IS NULL AND id > last_id
+           ORDER BY id LIMIT 10000
+           RETURNING id            # each batch = its own short transaction
+    if rows is empty: break
+    last_id = max(id in rows)
+    sleep 100ms                    # let autovacuum + replication catch up
+```
+Each batch commits independently, so no single long-running transaction holds locks or bloats WAL, and
+replicas don't fall behind. A single unbatched `UPDATE` of 10M rows would hold row locks and a huge
+transaction for minutes.
+
+**Why re-adding + backfilling `event_date` in M3's downgrade isn't sufficient for true rollback once
+Deploy B is live in production:**
+The downgrade restores the *column and its current data*, but rollback safety is about the *code*, not
+just the schema. Once Deploy B has been live, it has been writing **only** `scheduled_at` — so any rows
+created/updated during the Deploy-B window have a correct `scheduled_at` but the re-added `event_date`
+is only a point-in-time copy taken by the downgrade's `UPDATE`. If you then roll application code back to
+Deploy A (which dual-writes and reads `COALESCE`), it works for existing rows but there's a **gap**: writes
+that happened under Deploy B after the schema downgrade but before the code rollback would have updated
+`scheduled_at` only, leaving `event_date` stale — reads that fall through to `event_date` would return
+wrong values. For the rollback to be truly safe you'd need: (a) the old code still present and able to
+run, (b) a re-backfill of `event_date` from `scheduled_at` performed *after* the code rollback (not
+before), and (c) confidence no client cached the dropped column's absence. In practice, once the contract
+migration has run and Deploy B has taken production writes, the clean path is *forward* (fix-forward),
+not down — which is exactly why the drop is the point of no easy return.
+
+---
+
+## PR checklist
+
+```text
+- [x] Task 1 — multi-replica failover + 4 PDBs + topology spread + real eviction-API block
+- [x] Task 2 — preStop + zero-error rolling restart + CONCURRENTLY migration + expand-and-contract sketch
+- [x] Bonus Task — expand-and-contract executed live (3 migrations + 2 deploys, zero 5xx, event_date dropped)
+- [ ] (Optional) 12.9 HPA observation — skipped (non-graded, not in submit file list)
+```


### PR DESCRIPTION
## Lab 12 — Advanced Kubernetes Resilience

PodDisruptionBudgets, graceful shutdown, and a live zero-downtime schema migration for QuickTicket,
all executed on a local k3d cluster (5-replica gateway Rollout, events/payments/notifications at 2
replicas, in-cluster Prometheus, mixedload traffic).

### What's here
- `k8s/pdb.yaml` — 4 PodDisruptionBudgets (gateway minAvailable 2, events/payments 1, notifications maxUnavailable 1).
- `k8s/gateway.yaml` — Rollout + `topologySpreadConstraints` + `preStop` + fast `readinessProbe` + `terminationGracePeriodSeconds: 40`.
- `k8s/events.yaml` (2 replicas + preStop graceful shutdown), `k8s/payments.yaml`, `k8s/notifications.yaml` (2 replicas each).
- `migrations/` — Alembic chain incl. `CREATE INDEX CONCURRENTLY` (autocommit_block) + the 3 expand-and-contract migrations.
- `app/events/main.py` (Deploy B: reads `scheduled_at`), `app/seed.sql` (bootstraps on `scheduled_at`).
- `submissions/lab12.md` — full write-up with real evidence + all design answers.

### Evidence highlights
- **Failover:** killed a gateway + events pod under load → **0** 5xx.
- **PDBs:** `kubectl get pdb` allowed-disruptions 3/1/1/1; tightened-PDB eviction → **HTTP 429 reason=DisruptionBudget**.
- **Topology spread:** constraint live in the Rollout spec (single-node k3d places all 5 on one node, as expected).
- **Rolling restart** (`kubectl argo rollouts restart gateway`) under load → **0** 5xx (preStop + readiness).
- **`CONCURRENTLY` migration** ran in 0.296s under load, index visible in `\d events`, 0 5xx.
- **Bonus:** executed the live `event_date → scheduled_at` rename (3 migrations + 2 code deploys) with
  **zero 5xx delta** across all 5 transitions; `event_date` dropped, `scheduled_at` NOT NULL at the end.
  (events hardened with preStop first so both code deploys are genuinely zero-downtime.)

### PR checklist
- [x] Task 1 — multi-replica failover + 4 PDBs + topology spread + real eviction-API block
- [x] Task 2 — preStop + zero-error rolling restart + CONCURRENTLY migration + expand-and-contract sketch
- [x] Bonus Task — expand-and-contract executed live (3 migrations + 2 deploys, zero 5xx, event_date dropped)
