### PR TITLE
feat(lab12): PDBs, preStop, and zero-downtime migration

### DIFF
--- a/app/events/.dockerignore
+++ b/app/events/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+.git
+.env
+*.md
+.vscode

--- a/app/events/main.py
+++ b/app/events/main.py
@@ -140,11 +140,16 @@ def list_events():
     conn = db_pool.getconn()
     try:
         cur = conn.cursor()
+        # Deploy B (Lab 12 expand-and-contract): scheduled_at is backfilled and
+        # NOT NULL, so read it directly. Still aliased as event_date to keep the
+        # /events response shape byte-for-byte backward-compatible.
         cur.execute("""
-            SELECT e.id, e.name, e.venue, e.event_date, e.total_tickets, e.price_cents,
+            SELECT e.id, e.name, e.venue,
+                   e.scheduled_at AS event_date,
+                   e.total_tickets, e.price_cents,
                    COALESCE(SUM(o.quantity), 0) as confirmed
             FROM events e LEFT JOIN orders o ON e.id = o.event_id
-            GROUP BY e.id ORDER BY e.event_date
+            GROUP BY e.id ORDER BY e.scheduled_at
         """)
         rows = cur.fetchall()
         cur.close()
@@ -165,8 +170,11 @@ def get_event(event_id: int):
     conn = db_pool.getconn()
     try:
         cur = conn.cursor()
+        # Deploy B: read scheduled_at directly for the single-event read.
         cur.execute("""
-            SELECT e.id, e.name, e.venue, e.event_date, e.total_tickets, e.price_cents,
+            SELECT e.id, e.name, e.venue,
+                   e.scheduled_at AS event_date,
+                   e.total_tickets, e.price_cents,
                    COALESCE(SUM(o.quantity), 0) as confirmed
             FROM events e LEFT JOIN orders o ON e.id = o.event_id
             WHERE e.id = %s GROUP BY e.id

--- a/app/seed.sql
+++ b/app/seed.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS events (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     venue TEXT NOT NULL,
-    event_date TIMESTAMPTZ NOT NULL,
+    scheduled_at TIMESTAMPTZ NOT NULL,
     total_tickets INT NOT NULL,
     price_cents INT NOT NULL
 );
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS orders (
 );
 
 -- Seed events
-INSERT INTO events (name, venue, event_date, total_tickets, price_cents) VALUES
+INSERT INTO events (name, venue, scheduled_at, total_tickets, price_cents) VALUES
     ('Go Conference 2026', 'Main Hall A', '2026-09-15 09:00:00+00', 100, 5000),
     ('SRE Meetup', 'Room 204', '2026-10-01 18:00:00+00', 30, 0),
     ('Cloud Native Summit', 'Expo Center', '2026-11-20 10:00:00+00', 500, 15000),

--- a/k8s/events.yaml
+++ b/k8s/events.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: events
+  labels:
+    app: events
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: events
+  template:
+    metadata:
+      labels:
+        app: events
+    spec:
+      # preStop lets kube-proxy remove this pod's endpoint before uvicorn stops,
+      # so events code deploys (Lab 12 bonus) drop zero requests.
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: events
+          image: quickticket-events:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8081
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          env:
+            - name: DB_HOST
+              value: "postgres"
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: "quickticket"
+            - name: DB_USER
+              value: "quickticket"
+            - name: DB_PASS
+              value: "quickticket"
+            - name: REDIS_HOST
+              value: "redis"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: DB_MAX_CONNS
+              value: "10"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: events
+spec:
+  selector:
+    app: events
+  ports:
+    - port: 8081
+      targetPort: 8081

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -1,0 +1,97 @@
+apiVersion: argoproj.io/v1alpha1     # ← Changed
+kind: Rollout                         # ← Changed
+metadata:
+  name: gateway
+spec:
+  replicas: 5                         # ← Need 5 for meaningful canary splits
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20
+        - pause: { duration: 20s }
+        - analysis:
+            templates:
+              - templateName: gateway-error-rate
+            args:
+              - name: canary-hash
+                valueFrom:
+                  podTemplateHashValue: Latest
+        - setWeight: 50
+        - pause: { duration: 20s }
+        - setWeight: 100
+  selector:
+    matchLabels:
+      app: gateway
+  template:
+    metadata:
+      labels:
+        app: gateway
+        version: "v2"
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway     # don't block scheduling on single-node
+          labelSelector:
+            matchLabels:
+              app: gateway
+      # Give in-flight requests time to finish after SIGTERM (10s preStop + up to 30s drain).
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: gateway
+          image: quickticket-gateway:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          lifecycle:
+            # Sleep BEFORE SIGTERM reaches the app so kube-proxy / endpoints controllers
+            # propagate this pod's NotReady state to every node's iptables, stopping new
+            # traffic here BEFORE uvicorn shuts down (closes the SIGTERM+traffic RST window).
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          env:
+            - name: APP_VERSION
+              value: "v7"
+            - name: EVENTS_URL
+              value: "http://events:8081"
+            - name: PAYMENTS_URL
+              value: "http://payments:8082"
+            - name: NOTIFICATIONS_URL
+              value: "http://notifications:8083"
+            - name: GATEWAY_TIMEOUT_MS
+              value: "5000"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 2
+            failureThreshold: 1
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  selector:
+    app: gateway
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/k8s/notifications.yaml
+++ b/k8s/notifications.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notifications
+  labels:
+    app: notifications
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: notifications
+  template:
+    metadata:
+      labels:
+        app: notifications
+    spec:
+      containers:
+        - name: notifications
+          image: quickticket-notifications:v1
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8083
+          env:
+            - name: NOTIFY_FAILURE_RATE
+              value: "0.0"
+            - name: NOTIFY_LATENCY_MS
+              value: "0"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8083
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8083
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notifications
+spec:
+  selector:
+    app: notifications
+  ports:
+    - port: 8083
+      targetPort: 8083

--- a/k8s/payments.yaml
+++ b/k8s/payments.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  labels:
+    app: payments
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payments
+  template:
+    metadata:
+      labels:
+        app: payments
+    spec:
+      imagePullSecrets:
+        - name: ghcr-secret
+      containers:
+        - name: payments
+          image: ghcr.io/tulup-404/quickticket-payments:ec1eff1f8f289b277f31d8c3fef3bf5aad83da6d
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8082
+          env:
+            - name: PAYMENT_FAILURE_RATE
+              value: "0.0"
+            - name: PAYMENT_LATENCY_MS
+              value: "0"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments
+spec:
+  selector:
+    app: payments
+  ports:
+    - port: 8082
+      targetPort: 8082

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,45 @@
+# k8s/pdb.yaml — PodDisruptionBudgets for QuickTicket services.
+#
+# gateway-pdb        minAvailable: 2    (5 replicas, tolerate 3 evictions; critical path)
+# events-pdb         minAvailable: 1    (2 replicas, tolerate 1 eviction)
+# payments-pdb       minAvailable: 1    (2 replicas, tolerate 1 eviction)
+# notifications-pdb  maxUnavailable: 1  (best-effort, fire-and-forget)
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: gateway
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: events-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: events
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payments-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: payments
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notifications-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: notifications

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,78 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/62e2f6d2502b_add_events_scheduled_at_column.py
+++ b/migrations/versions/62e2f6d2502b_add_events_scheduled_at_column.py
@@ -1,0 +1,35 @@
+"""add events.scheduled_at column
+
+Revision ID: 62e2f6d2502b
+Revises: de677748fa9d
+Create Date: 2026-07-17 21:47:31.689738
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '62e2f6d2502b'
+down_revision: Union[str, Sequence[str], None] = 'de677748fa9d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Expand: add the new column, nullable so it is instant on a populated table.
+
+    A NOT NULL column with no default would fail to add to a table with existing
+    rows; even with a default, on a large table the rewrite takes an ACCESS
+    EXCLUSIVE lock. nullable=True is a metadata-only change — safe under traffic.
+    """
+    op.add_column(
+        "events",
+        sa.Column("scheduled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "scheduled_at")

--- a/migrations/versions/70b3c0332518_drop_events_event_date.py
+++ b/migrations/versions/70b3c0332518_drop_events_event_date.py
@@ -1,0 +1,39 @@
+"""drop events.event_date
+
+Revision ID: 70b3c0332518
+Revises: 716413418772
+Create Date: 2026-07-17 21:52:28.277994
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '70b3c0332518'
+down_revision: Union[str, Sequence[str], None] = '716413418772'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Contract: drop the old column now that Deploy B neither reads nor writes it.
+
+    Safe ONLY here: Deploy B is fully rolled out, so no live pod references
+    event_date. (Dropping the column also drops idx_events_event_date from 12.7,
+    since an index cannot outlive its column.) Running this before Deploy B was
+    complete would 500 every /events request on any surviving Deploy-A pod, whose
+    COALESCE still names event_date.
+    """
+    op.drop_column("events", "event_date")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("event_date", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.execute("UPDATE events SET event_date = scheduled_at")
+    op.alter_column("events", "event_date", nullable=False)

--- a/migrations/versions/716413418772_backfill_events_scheduled_at.py
+++ b/migrations/versions/716413418772_backfill_events_scheduled_at.py
@@ -1,0 +1,36 @@
+"""backfill events.scheduled_at
+
+Revision ID: 716413418772
+Revises: 62e2f6d2502b
+Create Date: 2026-07-17 21:49:59.876147
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '716413418772'
+down_revision: Union[str, Sequence[str], None] = '62e2f6d2502b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Backfill scheduled_at from event_date, then enforce NOT NULL.
+
+    Idempotent (WHERE scheduled_at IS NULL) so a re-run is a no-op. Safe under
+    live traffic because Deploy A reads via COALESCE and tolerates both NULL and
+    non-NULL scheduled_at. On a 10M-row table this UPDATE would be batched
+    (WHERE id BETWEEN x AND y, chunks of ~10k, sleeping between) to avoid a long
+    transaction lock; QuickTicket's 5-row seed finishes instantly.
+    """
+    op.execute("UPDATE events SET scheduled_at = event_date WHERE scheduled_at IS NULL")
+    op.alter_column("events", "scheduled_at", nullable=False)
+
+
+def downgrade() -> None:
+    # No need to UPDATE back — event_date still holds the data.
+    op.alter_column("events", "scheduled_at", nullable=True)

--- a/migrations/versions/de677748fa9d_index_events_event_date_concurrently.py
+++ b/migrations/versions/de677748fa9d_index_events_event_date_concurrently.py
@@ -1,0 +1,47 @@
+"""index events.event_date concurrently
+
+Revision ID: de677748fa9d
+Revises: 
+Create Date: 2026-07-17 21:37:14.391124
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'de677748fa9d'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create an index on events(event_date) using CONCURRENTLY.
+
+    CREATE INDEX CONCURRENTLY cannot run inside a transaction block, and Alembic
+    wraps migrations in a transaction by default — so we open an autocommit block
+    for the DDL. if_not_exists keeps the migration re-runnable if interrupted.
+    """
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "idx_events_event_date",
+            "events",
+            ["event_date"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    """Drop the index (mirror of upgrade, also concurrently / if_exists)."""
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_events_event_date",
+            table_name="events",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/submissions/lab12.md
+++ b/submissions/lab12.md
@@ -1,0 +1,431 @@
+# Lab 12 — Bonus: Advanced Kubernetes Resilience
+
+> Environment note: the running k3d cluster carries the accumulated state from Labs 7/9/11
+> (gateway is a 5-replica Argo `Rollout` on the local `quickticket-gateway:v1` image with
+> notifications wired in; events runs with `DB_MAX_CONNS`; `k8s/notifications.yaml` exists).
+> The manifests in this PR were reconciled to that live state before the Lab-12 deltas were
+> applied, so `kubectl apply` only changes what each task asks for (replicas, PDBs, topology
+> spread) and never regresses the gateway image.
+
+---
+
+## Task 1 — Multi-Replica Failover + PDBs (4 pts)
+
+### 1. `kubectl get deploy,rollout` — all services at target replica counts
+
+```
+NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/events          2/2     2            2           15d
+deployment.apps/mixedload       2/2     2            2           7d18h
+deployment.apps/notifications   2/2     2            2           15h
+deployment.apps/payments        2/2     2            2           15d
+deployment.apps/postgres        1/1     1            1           15d
+deployment.apps/redis           1/1     1            1           15d
+
+NAME                          DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+rollout.argoproj.io/gateway   5         5         5            5           15d
+```
+
+events / payments / notifications scaled to **2/2**; gateway stays a 5-replica Rollout.
+
+### 2. Before / after 5xx around the coordinated pod kill
+
+Coordinated kill with the lab's command — `kubectl delete pod <gateway> <events> --wait=false` —
+one gateway pod and one events pod deleted together under live mixedload.
+
+> Note on the metric: gateway `/health` runs a *deep* dependency check, so kubelet probes can
+> occasionally log an internal `GET /health` 503 that has nothing to do with user traffic. Both
+> the raw counter and a `path!="/health"` (user-facing) counter are shown; here both are 0.
+
+```
+# BEFORE
+raw          sum(increase(gateway_requests_total{status=~"5.."}[3m]))                 = 0
+user-facing  sum(increase(gateway_requests_total{status=~"5..",path!="/health"}[3m])) = 0 (empty vector)
+
+# kubectl delete pod (real)
+pod "gateway-588d5b74c7-bklsb" deleted
+pod "events-686c96c4d9-8tmsg"  deleted
+# recovery: events back to 2/2, gateway back to 5/5 within seconds
+
+# AFTER (1m window covers the kill)
+raw          sum(increase(gateway_requests_total{status=~"5.."}[1m]))                 = 0
+user-facing  sum(increase(...,path!="/health"}[1m]))                                   = 0
+user-facing  sum(increase(...,path!="/health"}[3m]))                                   = 0
+```
+
+**Zero 5xx (raw and user-facing) through the kill.** The surviving replica served all traffic while
+the Deployment/ReplicaSet rescheduled the deleted pod. (Deleting a pod not created via `kubectl run`
+prints a harmless "no need to specify a resource type" hint on some kubectl versions; the delete
+still succeeds.)
+
+### 3. `kubectl get pdb`
+
+```
+NAME                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+events-pdb          1               N/A               1                     14h
+gateway-pdb         2               N/A               3                     14h
+notifications-pdb   N/A             1                 1                     14h
+payments-pdb        1               N/A               1                     14h
+```
+
+Matches the spec: gateway `2 / N/A / 3`, events `1 / N/A / 1`, payments `1 / N/A / 1`,
+notifications `N/A / 1 / 1`.
+
+### 4. Topology spread — live in spec + actual placement
+
+`kubectl get rollout gateway -o jsonpath='{.spec.template.spec.topologySpreadConstraints}'`:
+
+```json
+[
+  {
+    "labelSelector": { "matchLabels": { "app": "gateway" } },
+    "maxSkew": 1,
+    "topologyKey": "kubernetes.io/hostname",
+    "whenUnsatisfiable": "ScheduleAnyway"
+  }
+]
+```
+
+`kubectl get pod -l app=gateway` placement (single-node k3d — all on the only node, as expected):
+
+```
+gateway-b5d9bff45-g29vz   Running   k3d-quickticket-server-0
+gateway-b5d9bff45-hgnl9   Running   k3d-quickticket-server-0
+gateway-b5d9bff45-rshcz   Running   k3d-quickticket-server-0
+gateway-b5d9bff45-x4vnj   Running   k3d-quickticket-server-0
+gateway-b5d9bff45-zrt7m   Running   k3d-quickticket-server-0
+```
+
+The constraint is correct and live; it simply has nothing to spread across on a 1-node cluster.
+
+### 5. PDB actually blocks eviction — HTTP 429 body
+
+`events-pdb` tightened to `minAvailable: 2` (2 replicas → `ALLOWED DISRUPTIONS = 0`), then one
+eviction fired via `POST /api/v1/namespaces/default/pods/<pod>/eviction`:
+
+```
+HTTP_STATUS=429
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "status": "Failure",
+  "message": "Cannot evict pod as it would violate the pod's disruption budget.",
+  "reason": "TooManyRequests",
+  "details": {
+    "causes": [
+      {
+        "reason": "DisruptionBudget",
+        "message": "The disruption budget events-pdb needs 2 healthy pods and has 2 currently"
+      }
+    ]
+  },
+  "code": 429
+}
+```
+
+PDB restored to `minAvailable: 1` afterward.
+
+### 6. PDB math
+
+**"With 3 gateway replicas and `minAvailable: 1`, what's the maximum number of pods that can be
+evicted simultaneously?"** — The API computes `ALLOWED DISRUPTIONS = healthy − minAvailable = 3 − 1 = 2`.
+So at most **2** pods can be voluntarily evicted at once; the 3rd eviction is rejected with 429
+until a replacement becomes healthy.
+
+**"Why is `gateway-pdb` set to `minAvailable: 2` with 5 replicas?"** — It permits `5 − 2 = 3`
+simultaneous evictions, which is enough to let a node drain reschedule pods while still keeping
+~half the normal RPS capacity serving. Setting `minAvailable: 4` would allow only 1 eviction and
+would make a rolling node drain block (potentially forever) because the drain can't get enough
+pods off the node at once. `2` balances "keep serving" against "let maintenance actually happen."
+
+### 7. Topology spread placement on a real multi-node cluster
+
+With `maxSkew: 1` across `kubernetes.io/hostname` on a **3-node** cluster:
+
+- **5 gateway pods → 2 / 2 / 1.** The most-loaded node has 2, the least-loaded has 1, skew = 1 ✓.
+  Placements like 3/1/1 (skew 2) or 4/1/0 are forbidden.
+- **7 gateway pods → 3 / 2 / 2.** Max = 3, min = 2, skew = 1 ✓. (3/3/1 would be skew 2 → rejected.)
+
+On single-node k3d the skew is trivially 0 (everything on one node), which is why the effect is
+not observable here.
+
+---
+
+## Task 2 — Graceful Shutdown + Zero-Downtime Migration (4 pts)
+
+### 12.6 — `preStop` + `readinessProbe` (as in `k8s/gateway.yaml`)
+
+```yaml
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: gateway
+          ...
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 2
+            failureThreshold: 1
+```
+
+Verified live in the Rollout spec:
+
+```
+termGrace=40
+preStop={"exec":{"command":["sh","-c","sleep 10"]}}
+readiness={"failureThreshold":1,"httpGet":{"path":"/health","port":8080},"periodSeconds":2}
+```
+
+### Rolling restart under load — 5xx before / after
+
+Restarted with the lab's command, `kubectl argo rollouts restart gateway` (plugin v1.9.1):
+
+```
+$ kubectl argo rollouts restart gateway
+rollout 'gateway' restarts in 0s
+$ kubectl argo rollouts status gateway --timeout=240s
+Progressing - rollout is restarting
+Healthy
+
+BEFORE  raw[1m]          = 0 (empty vector)
+BEFORE  user-facing[3m]  = 0
+# all 5 pods replaced one at a time, each draining gracefully via preStop
+AFTER   raw[3m]          = 0
+AFTER   user-facing[3m]  = 0
+```
+
+**Zero 5xx during the rolling restart.** preStop held SIGTERM 10s while the endpoint removal
+propagated, and the fast readinessProbe pulled each pod out of the Service before uvicorn stopped.
+
+### 12.7 — `CREATE INDEX CONCURRENTLY` migration
+
+`migrations/versions/de677748fa9d_index_events_event_date_concurrently.py`:
+
+```python
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "idx_events_event_date",
+            "events",
+            ["event_date"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "idx_events_event_date",
+            table_name="events",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+```
+
+The `autocommit_block()` is the key detail — without it Alembic runs the DDL inside its default
+transaction and Postgres rejects `CREATE INDEX CONCURRENTLY` with `ActiveSqlTransaction`.
+
+> Env note: on this machine port 5432 is already held by a native Postgres, so Alembic was
+> pointed at a `kubectl port-forward svc/postgres 15432:5432` for the run; `alembic.ini` is left
+> at the lab-standard `5432`. Also, `migrations/env.py` + `script.py.mako` were missing from the
+> working tree and were restored from the Lab 9 branch so the toolchain would run.
+
+Run under live mixedload — 5xx before / after (counter, not increase):
+
+```
+BEFORE 5xx counter: {"...","result":[]}          # empty = 0
+
+$ time alembic upgrade head
+INFO ... Running upgrade  -> de677748fa9d, index events.event_date concurrently
+real    0m1.355s
+
+AFTER  5xx counter: {"...","result":[]}          # empty = 0
+diff /tmp/5xx.before /tmp/5xx.after  ->  NO CHANGE (zero 5xx delta)
+```
+
+`\d events` after the migration:
+
+```
+Indexes:
+    "events_pkey" PRIMARY KEY, btree (id)
+    "idx_events_event_date" btree (event_date)
+```
+
+### 12.8 — Expand-and-contract sketch: rename `event_date` → `scheduled_at` (design only)
+
+**3 migrations + 2 code deploys, interleaved. At every step both old and new code must work.**
+
+1. **Migration 1 — expand.** `ALTER TABLE events ADD COLUMN scheduled_at TIMESTAMPTZ NULL;`
+   Nullable so it's an instant metadata-only change (a `NOT NULL`/defaulted add would rewrite the
+   whole table under an `ACCESS EXCLUSIVE` lock).
+2. **Code deploy A — dual-write, fallback-read.** App writes both `event_date` and `scheduled_at`;
+   reads `COALESCE(scheduled_at, event_date)`. Works whether or not a row is backfilled yet.
+3. **Migration 2 — backfill + tighten.** `UPDATE events SET scheduled_at = event_date WHERE scheduled_at IS NULL;`
+   then `ALTER COLUMN scheduled_at SET NOT NULL`. Safe under traffic: Deploy A tolerates NULL via
+   COALESCE, and the `WHERE ... IS NULL` makes it idempotent/re-runnable. (At 10M rows you'd batch
+   by id range with sleeps between chunks to keep each transaction short.)
+4. **Code deploy B — switch to new column only.** Read and write only `scheduled_at` (drop the
+   COALESCE and the dual-write). Now nothing references `event_date`.
+5. **Migration 3 — contract.** `ALTER TABLE events DROP COLUMN event_date;` Only safe once Deploy B
+   is fully rolled out — see the answer below.
+
+### Task 2 answers
+
+**"Why does `CREATE INDEX CONCURRENTLY` matter? What happens if you omit it on a 10M-row table?"**
+A plain `CREATE INDEX` takes an `ACCESS EXCLUSIVE` lock on the table for the entire build — on 10M
+rows that's minutes during which *every* read and write blocks (an effective outage). `CONCURRENTLY`
+builds the index with a milder `SHARE UPDATE EXCLUSIVE` lock that doesn't block reads or writes; it
+costs a second table scan and can't run inside a transaction, but the table stays fully available.
+
+**"Why MUST migration 3 (drop `event_date`) come after Deploy B is fully rolled out?"**
+Until Deploy B is everywhere, some pods still run Deploy A, which reads/writes `event_date`
+(via COALESCE and dual-write). If migration 3 drops the column while any Deploy-A pod is live, every
+`/events` request that pod serves 500s (SELECT/INSERT references a column that no longer exists), and
+new writes lose data. Dropping is only safe once *no running code* touches `event_date` — i.e. after
+`kubectl rollout status` confirms Deploy B fully replaced Deploy A.
+
+---
+
+## Bonus Task — Execute the Expand-and-Contract Rename (2 pts)
+
+Executed live on the cluster under mixedload, following the same shape as reference
+[PR #331](https://github.com/inno-devops-labs/SRE-Intro/pull/331). `events` was first hardened with
+a `preStop` hook + `terminationGracePeriodSeconds: 40` and moved to a locally-built
+`quickticket-events:v1` image (`imagePullPolicy: Never`) so both code deploys are genuinely
+zero-downtime. QuickTicket has **no runtime INSERT** of event rows — the only writer is
+`app/seed.sql` at boot — so there is no dual-**write** path; only the reads change, and `seed.sql`
+is switched to `scheduled_at` in Deploy B.
+
+### 1. The three migration files (upgrade bodies)
+
+```python
+# M1 — add_events_scheduled_at_column  (revises: index migration)
+def upgrade():
+    op.add_column("events",
+        sa.Column("scheduled_at", sa.TIMESTAMP(timezone=True), nullable=True))
+
+# M2 — backfill_events_scheduled_at
+def upgrade():
+    op.execute("UPDATE events SET scheduled_at = event_date WHERE scheduled_at IS NULL")
+    op.alter_column("events", "scheduled_at", nullable=False)
+
+# M3 — drop_events_event_date
+def upgrade():
+    op.drop_column("events", "event_date")
+```
+
+Alembic history (chained after the 12.7 index migration):
+
+```
+<base> -> de677748fa9d, index events.event_date concurrently
+de677748fa9d -> 62e2f6d2502b, add events.scheduled_at column
+62e2f6d2502b -> 716413418772, backfill events.scheduled_at
+716413418772 -> 70b3c0332518 (head), drop events.event_date
+```
+
+### 2. `app/events/main.py` — Deploy A → Deploy B (read path)
+
+```diff
+- # Deploy A: prefer scheduled_at, fall back to event_date (COALESCE).
+-   COALESCE(e.scheduled_at, e.event_date) AS event_date,
+-   ... GROUP BY e.id ORDER BY COALESCE(e.scheduled_at, e.event_date)
++ # Deploy B: scheduled_at is backfilled + NOT NULL, read it directly.
++   e.scheduled_at AS event_date,
++   ... GROUP BY e.id ORDER BY e.scheduled_at
+```
+
+The `AS event_date` alias is kept through Deploy B so the `/events` response shape stays
+byte-for-byte identical — the gateway and clients never see the rename. `app/seed.sql` switched
+`event_date` → `scheduled_at` in the CREATE TABLE and the INSERT (so a fresh cluster boots on the
+new schema).
+
+### 3. `\d events` before M1 vs after M3
+
+```console
+# BEFORE M1 (has event_date NOT NULL + the 12.7 index)
+ event_date    | timestamp with time zone | not null
+Indexes:
+    "events_pkey" PRIMARY KEY, btree (id)
+    "idx_events_event_date" btree (event_date)
+
+# AFTER M3 (event_date gone; scheduled_at NOT NULL; index dropped with its column)
+ scheduled_at  | timestamp with time zone | not null
+Indexes:
+    "events_pkey" PRIMARY KEY, btree (id)
+```
+
+### 4. Zero 5xx across the whole sequence
+
+Snapshot after the events-hardening step, then a delta check after each of M1 / Deploy A / M2 /
+Deploy B / M3:
+
+```
+5xx baseline value (post-hardening) : 1
+5xx final    value (after M3)       : 1      -> delta 0
+user-facing 5xx (path!="/health") all-time : 0   (no user-facing 5xx ever)
+```
+
+The `1` is a single internal `GET /health` 503 from the one-off ghcr→local events image switch;
+it is *in the baseline*, so the **delta across the five graded transitions is 0**. Every `/events`
+read stayed 2xx throughout (verified live after each deploy).
+
+### 5. Which single step would have caused 5xx if reordered earlier?
+
+**Migration 3 (drop `event_date`).** If it ran before Deploy B was fully rolled out, any surviving
+Deploy-A pod — whose query still names `event_date` via COALESCE — would 500 on *every* `/events`
+request the instant the column disappeared. (M1 add-column and M2 backfill are both additive/safe at
+any time; Deploy A only adds a fallback; Deploy B only removes an already-redundant fallback.) The
+drop is the one irreversible removal, so it must come strictly last.
+
+### 6. Batching pattern for a 10M-row backfill
+
+```
+last_id = 0
+while True:
+    rows = execute("""
+        UPDATE events SET scheduled_at = event_date
+        WHERE id > :last_id AND id <= :last_id + 10000 AND scheduled_at IS NULL
+        RETURNING id
+    """, last_id=last_id)      # each UPDATE is its own short transaction
+    if not rows:
+        break
+    last_id += 10000
+    sleep(0.1)                 # let autovacuum + replication catch up between chunks
+```
+
+Each chunk commits independently, so no single long transaction holds locks or bloats WAL; the table
+stays writable the whole time.
+
+### 7. Why re-adding `event_date` in M3's downgrade isn't sufficient for true rollback safety
+
+M3's `downgrade()` re-creates `event_date` and backfills it from `scheduled_at` — so the *schema* is
+restored. But once Deploy B is live in production, rolling **back the schema alone doesn't roll back
+the code**: any new rows written while Deploy B ran only have `scheduled_at` set through the app's
+current path, and — more importantly — a true rollback also has to redeploy Deploy A (or earlier)
+code, and that code must still tolerate the intermediate states. Rollback is only safe if (a) Deploy
+A code is still deployable and reads via COALESCE (so it works whether or not `event_date` is
+back-populated yet), and (b) the down-migration runs its backfill *before* any Deploy-A pod serves
+traffic. In other words, rollback is itself an expand-and-contract in reverse — you can't just drop
+the column back in and flip the image; you sequence it the same careful way.
+
+---
+
+## Notes / deviations from the lab text
+
+- **Working tree vs. live cluster:** the repo was on `main`, whose manifests lagged the running
+  cluster (older ghcr tags, no `k8s/notifications.yaml`, gateway on a pre-lab11 image). Each manifest
+  was reconciled to the live lab-7/9/11 state before applying the Lab-12 deltas, so nothing regressed.
+- **Alembic chain starts at the index migration** (`down_revision = None`), not at a lab9 baseline:
+  this DB had no `alembic_version` table and no lab9 `email` column, and `migrations/env.py` +
+  `script.py.mako` were missing from the tree (restored from the Lab 9 branch so the toolchain runs).
+  The lab-12 migration bodies are unchanged; only the chain root differs.
+- **Port 5432 held by a native Postgres** → Alembic ran against `kubectl port-forward svc/postgres
+  15432:5432`; `alembic.ini` is left at the lab-standard `5432`.
+- **`/health` 503 noise:** the gateway's `/health` does a deep dependency check, so kubelet probes
+  can log an internal 503 unrelated to user traffic. Any raw 5xx seen are these internal probes;
+  user-facing paths (`/events`, `/events/{id}/reserve`) never 5xx.


### PR DESCRIPTION
- [x] Task 1 done — multi-replica failover + 4 PDBs + topology spread + real eviction-API block
- [x] Task 2 done — preStop + zero-error rolling restart + CONCURRENTLY migration + expand-and-contract sketch
- [x] Bonus Task done — expand-and-contract executed live (3 migrations + 2 deploys, zero 5xx, `event_date` dropped)
- [ ] (Optional) 12.9 HPA observation